### PR TITLE
Security alert: update version of jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
     <version.dc-commons>1.3.0</version.dc-commons>
     <version.iiif-apis>0.3.3</version.iiif-apis>
-    <version.jackson>2.9.5</version.jackson>
+    <version.jackson>2.9.8</version.jackson>
     <version.logstash-logback-encoder>5.1</version.logstash-logback-encoder>
     <version.mongeez>0.9.6</version.mongeez>
     <version.persistence-api>1.0.2</version.persistence-api>


### PR DESCRIPTION
This PR updates the version of `jackson` to fix CVE-2018-19360, CVE-2018-19362 and CVE-2018-19361.

This was found during a GitHub Security Scan.