### PR TITLE
Add OpenGraph tags and Twitter Cards

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>de.digitalcollections</groupId>
   <artifactId>iiif-bookshelf-webapp</artifactId>
-  <version>3.1.4-SNAPSHOT</version>
+  <version>3.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <url>https://github.com/dbmdz/iiif-bookshelf-webapp</url>

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/config/SharingConfig.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/config/SharingConfig.java
@@ -1,0 +1,50 @@
+package de.digitalcollections.iiif.bookshelf.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SharingConfig {
+
+  private String previewImageUrl;
+
+  private Integer previewImageWidth;
+
+  private Integer previewImageHeight;
+
+  private String twitterSiteHandle;
+
+  public SharingConfig(
+      @Value("${custom.sharing.previewImage.url:#{null}}") String previewImageUrl,
+      @Value("${custom.sharing.previewImage.width:#{null}}") String previewImageWidth,
+      @Value("${custom.sharing.previewImage.height:#{null}}") String previewImageHeight,
+      @Value("${custom.sharing.twitter.siteHandle:#{null}}") String twitterSiteHandle
+  ) {
+    this.previewImageUrl = previewImageUrl;
+    if (previewImageHeight != null) {
+      this.previewImageHeight = Integer.parseInt(previewImageHeight);
+    }
+    if (previewImageWidth != null) {
+      this.previewImageWidth = Integer.parseInt(previewImageWidth);
+    }
+
+    this.twitterSiteHandle = twitterSiteHandle;
+  }
+
+  public String getPreviewImageUrl() {
+    return previewImageUrl;
+  }
+
+  public Integer getPreviewImageWidth() {
+    return previewImageWidth;
+  }
+
+  public Integer getPreviewImageHeight() {
+    return previewImageHeight;
+  }
+
+  public String getTwitterSiteHandle() {
+    return twitterSiteHandle;
+  }
+
+}

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/frontend/controller/WebController.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/frontend/controller/WebController.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Maps;
 import de.digitalcollections.commons.springmvc.controller.AbstractController;
 import de.digitalcollections.iiif.bookshelf.business.api.service.IiifCollectionService;
 import de.digitalcollections.iiif.bookshelf.business.api.service.IiifManifestSummaryService;
+import de.digitalcollections.iiif.bookshelf.config.SharingConfig;
 import de.digitalcollections.iiif.bookshelf.frontend.model.PageWrapper;
 import de.digitalcollections.iiif.bookshelf.model.IiifManifestSummary;
 import de.digitalcollections.iiif.bookshelf.model.SearchRequest;
@@ -68,8 +69,8 @@ public class WebController extends AbstractController {
   @Autowired
   private ObjectMapper objectMapper;
 
-  @Value("twitter.siteHandle")
-  private String twitterSiteHandle;
+  @Autowired
+  private SharingConfig sharingConfig;
 
   /**
    * List with or without search query.
@@ -93,6 +94,11 @@ public class WebController extends AbstractController {
     model.addAttribute("page", new PageWrapper<>(page, "/"));
     model.addAttribute("searchRequest", new SearchRequest());
     model.addAttribute("style", style);
+
+    model.addAttribute("preview", sharingConfig.getPreviewImageUrl());
+    model.addAttribute("previewWidth", sharingConfig.getPreviewImageWidth());
+    model.addAttribute("previewHeight", sharingConfig.getPreviewImageHeight());
+    model.addAttribute("twitterSiteHandle", sharingConfig.getTwitterSiteHandle());
 
     // model.addAttribute("manifests", iiifManifestSummaryService.getAll());
     // model.addAttribute("count", iiifManifestSummaryService.countAll());
@@ -235,7 +241,7 @@ public class WebController extends AbstractController {
     } catch (IOException e) {
       model.addAttribute("error_message", messageSource.getMessage("manifest_error", new Object[]{}, locale));
     }
-    model.addAttribute("twitterSiteHandle", twitterSiteHandle);
+    model.addAttribute("twitterSiteHandle", sharingConfig.getTwitterSiteHandle());
   }
 
 

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/util/PreviewImageUtil.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/util/PreviewImageUtil.java
@@ -1,0 +1,110 @@
+package de.digitalcollections.iiif.bookshelf.util;
+
+import de.digitalcollections.iiif.model.ImageContent;
+import de.digitalcollections.iiif.model.Service;
+import de.digitalcollections.iiif.model.image.ImageService;
+import de.digitalcollections.iiif.model.openannotation.Annotation;
+import de.digitalcollections.iiif.model.sharedcanvas.Canvas;
+import de.digitalcollections.iiif.model.sharedcanvas.Manifest;
+import de.digitalcollections.iiif.model.sharedcanvas.Resource;
+import de.digitalcollections.iiif.model.sharedcanvas.Sequence;
+import java.net.URI;
+import java.util.List;
+
+public class PreviewImageUtil {
+
+  private final Manifest manifest;
+
+  public PreviewImageUtil(Manifest manifest) {
+    this.manifest = manifest;
+  }
+
+
+  public static ImageService findImageService(List<Service> services) {
+    if (services == null) {
+      return null;
+    }
+    for (Service service : services) {
+      if (service instanceof ImageService) {
+        return (ImageService) service;
+      }
+    }
+    return null;
+  }
+
+  public ImageContent findImageResource(URI imageServiceURI) {
+    if (imageServiceURI == null) {
+      return null;
+    }
+    if (manifest.getSequences() == null) {
+      return null;
+    }
+    for (Sequence sequence : manifest.getSequences()) {
+      if (sequence.getCanvases() == null) {
+        continue;
+      }
+      for (Canvas canvas : sequence.getCanvases()) {
+        if (canvas.getImages() == null) {
+          continue;
+        }
+        for (Annotation image : canvas.getImages()) {
+          if (image.getResource() == null) {
+            continue;
+          }
+          Resource<?> resource = image.getResource();
+          ImageService imageService = findImageService(resource.getServices());
+          if (imageService != null && imageServiceURI.equals(imageService.getIdentifier())) {
+            return (ImageContent) resource;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  public ImageContent findBestPreviewImage() {
+    ImageContent preview = manifest.getThumbnail();
+    if (preview == null) {
+      return findFirstImage();
+    }
+
+    List<Service> services = manifest.getThumbnail().getServices();
+    ImageService imageService = findImageService(services);
+    if (imageService == null) {
+      return findFirstImage();
+    }
+
+    URI imageServiceURI = imageService.getIdentifier();
+    ImageContent betterPreview = findImageResource(imageServiceURI);
+    if (betterPreview == null) {
+      return preview;
+    }
+
+    return betterPreview;
+  }
+
+  public ImageContent findFirstImage() {
+    if (manifest.getSequences() == null) {
+      return null;
+    }
+    for (Sequence sequence : manifest.getSequences()) {
+      if (sequence.getCanvases() == null) {
+        continue;
+      }
+      for (Canvas canvas : sequence.getCanvases()) {
+        if (canvas.getImages() == null) {
+          continue;
+        }
+        for (Annotation image : canvas.getImages()) {
+          if (image.getResource() == null) {
+            continue;
+          }
+          return (ImageContent) image.getResource();
+        }
+      }
+    }
+    return null;
+  }
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,8 +19,15 @@ custom:
   summary:
     thumbnail:
       width: 280
-  twitter:
-    siteHandle: '@yourhappytwitterhandle'
+
+  sharing:
+    twitter:
+      siteHandle: '@yourhappytwitterhandle'
+    previewImage:
+      url: 'images/iiif-logo.svg'
+      width: 441
+      height: 493
+
 # end of custom configuration section
 
 info:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,8 @@ custom:
   summary:
     thumbnail:
       width: 280
+  twitter:
+    siteHandle: '@yourhappytwitterhandle'
 # end of custom configuration section
 
 info:

--- a/src/main/resources/templates/base.html
+++ b/src/main/resources/templates/base.html
@@ -31,6 +31,8 @@
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <script th:src="@{/webjars/html5shiv/3.7.3/html5shiv.min.js}"></script>
     <script th:src="@{/webjars/respond.js/1.4.2/dest/respond.min.js}"></script>
+
+    <meta th:replace="fragments/sharing_metadata.html :: twitterAndOG" />
   </head>
 
   <body>

--- a/src/main/resources/templates/fragments/sharing_metadata.html
+++ b/src/main/resources/templates/fragments/sharing_metadata.html
@@ -5,7 +5,7 @@
   <body>
 
   <th:block th:fragment="twitterAndOG">
-    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:card" th:if="${twitterSiteHandle}" content="summary" />
     <meta name="twitter:site" th:if="${twitterSiteHandle}" th:content="${twitterSiteHandle}" />
 
     <meta property="og:image" th:if="${preview}"
@@ -20,7 +20,7 @@
     <meta property="og:title" th:if="${title}"
           th:content="${title}"
           content="Naval affairs of England - BSB Cod.angl. 2"/>
-    <meta property="og:description" th:if="${manifest.description}"
+    <meta property="og:description" th:if="${manifest != null and manifest.description != null}"
           th:content="${manifest.description}"
           content="Sammelhandschrift"/>
   </th:block>

--- a/src/main/resources/templates/fragments/sharing_metadata.html
+++ b/src/main/resources/templates/fragments/sharing_metadata.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+  </head>
+  <body>
+
+  <th:block th:fragment="twitterAndOG">
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" th:if="${twitterSiteHandle}" th:content="${twitterSiteHandle}" />
+
+    <meta property="og:image" th:if="${preview}"
+          th:content ="${preview}"
+          content="https://api.digitale-sammlungen.de/iiif/image/v2/bsb00110131_00011/full/full/0/default.jpg"/>
+    <meta property="og:image:width" th:if="${previewWidth}"
+          th:content="${previewWidth}"
+          content="4683"/>
+    <meta property="og:image:height" th:if="${previewHeight}"
+          th:content="${previewHeight}"
+          content="7121"/>
+    <meta property="og:title" th:if="${title}"
+          th:content="${title}"
+          content="Naval affairs of England - BSB Cod.angl. 2"/>
+    <meta property="og:description" th:if="${manifest.description}"
+          th:content="${manifest.description}"
+          content="Sammelhandschrift"/>
+  </th:block>
+
+  <th:block th:fragment="twitterCards">
+
+  </th:block>
+
+</body>
+</html>

--- a/src/main/resources/templates/info.html
+++ b/src/main/resources/templates/info.html
@@ -5,6 +5,8 @@
   <head>
     <title th:utext="${title}">Label of manifest in current locale</title>
     <meta property="og:title" th:attr="content=${title}">
+
+    <meta th:replace="fragments/sharing_metadata.html :: twitterAndOG" />
   </head>
   <body>
     <section layout:fragment="content">

--- a/src/main/resources/templates/mirador/view.html
+++ b/src/main/resources/templates/mirador/view.html
@@ -13,8 +13,6 @@
       body > div.container { width: 100% !important; }
     </style>
     <title th:utext="${title}">Label of manifest in current locale</title>
-
-    <meta th:replace="fragments/sharing_metadata.html :: twitterAndOG" />
   </head>
 
   <body>

--- a/src/main/resources/templates/mirador/view.html
+++ b/src/main/resources/templates/mirador/view.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:og="http://ogp.me/"
       layout:decorate="~{base}">
   <head>
     <link rel="stylesheet" type="text/css" th:href="@{|/webjars/mirador/${iiifVersions.mirador}/css/mirador-combined.css|}">
@@ -12,8 +13,15 @@
       body > div.container { width: 100% !important; }
     </style>
     <title th:utext="${title}">Label of manifest in current locale</title>
+
+    <meta th:replace="fragments/sharing_metadata.html :: twitterAndOG" />
   </head>
+
   <body>
+    <p th:content="${preview}"></p>
+    <p th:content="${previewWidth}"></p>
+    <p th:content="${previewHeight}"></p>
+
     <section layout:fragment="content">
       <div class="row">
         <div class="col-md-12">

--- a/src/main/resources/templates/uv/view.html
+++ b/src/main/resources/templates/uv/view.html
@@ -5,8 +5,6 @@
   <head>
     <link rel="stylesheet" th:href="@{/css/viewer.css}">
     <title th:utext="${title}">Label of manifest in current locale</title>
-
-    <meta th:replace="fragments/sharing_metadata.html :: twitterAndOG" />
   </head>
   <body>
     <section layout:fragment="content">

--- a/src/main/resources/templates/uv/view.html
+++ b/src/main/resources/templates/uv/view.html
@@ -5,6 +5,8 @@
   <head>
     <link rel="stylesheet" th:href="@{/css/viewer.css}">
     <title th:utext="${title}">Label of manifest in current locale</title>
+
+    <meta th:replace="fragments/sharing_metadata.html :: twitterAndOG" />
   </head>
   <body>
     <section layout:fragment="content">


### PR DESCRIPTION
This PR adds metadata tags for best sharing on social media like Facebook and Twitter on any page if basic metadata is defined. Metadata for an object's overview, Mirador and Universal Viewer pages is taken from the object's manifest.