### PR TITLE
Fix description and add more OpenGraph and TwitterCard-Tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>de.digitalcollections</groupId>
   <artifactId>iiif-bookshelf-webapp</artifactId>
-  <version>3.2.0</version>
+  <version>3.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <url>https://github.com/dbmdz/iiif-bookshelf-webapp</url>

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/frontend/controller/WebController.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/frontend/controller/WebController.java
@@ -13,6 +13,7 @@ import de.digitalcollections.iiif.bookshelf.model.exceptions.NotFoundException;
 import de.digitalcollections.iiif.bookshelf.model.exceptions.SearchSyntaxException;
 import de.digitalcollections.iiif.bookshelf.util.PreviewImageUtil;
 import de.digitalcollections.iiif.model.ImageContent;
+import de.digitalcollections.iiif.model.PropertyValue;
 import de.digitalcollections.iiif.model.sharedcanvas.Manifest;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -231,6 +232,10 @@ public class WebController extends AbstractController {
     try {
       Manifest manifest = objectMapper.readValue(new URL(manifestUri), Manifest.class);
       model.addAttribute("manifest", manifest);
+      PropertyValue description = manifest.getDescription();
+      if (description != null) {
+        model.addAttribute("description", description.getFirstValue(locale));
+      }
 
       ImageContent preview = new PreviewImageUtil(manifest).findBestPreviewImage();
       if (preview != null) {

--- a/src/main/resources/templates/base.html
+++ b/src/main/resources/templates/base.html
@@ -8,7 +8,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!--/* The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags */-->
-    <meta name="description" content="">
+    <meta name="description" th:if="${description}"
+          th:content="${description}"
+          content="Dieser Prachteinband der ottonischen Epoche zählt zu den weltweit bedeutendsten Exemplaren; als Spolien wurden unter anderem eine karolingische Elfenbeintafel, mittelbyzantinische sowie ottonische Emails verwendet. // Karl-Georg Pfändtner"/>
     <link rel="shortcut icon" th:href="@{/images/favicon.ico}" type="image/ico">
 
     <title layout:title-pattern="$LAYOUT_TITLE: $CONTENT_TITLE">IIIF Bookshelf</title>

--- a/src/main/resources/templates/fragments/sharing_metadata.html
+++ b/src/main/resources/templates/fragments/sharing_metadata.html
@@ -20,8 +20,8 @@
     <meta property="og:title" th:if="${title}"
           th:content="${title}"
           content="Naval affairs of England - BSB Cod.angl. 2"/>
-    <meta property="og:description" th:if="${manifest != null and manifest.description != null}"
-          th:content="${manifest.description}"
+    <meta property="og:description" th:if="${description}"
+          th:content="${description}"
           content="Sammelhandschrift"/>
   </th:block>
 

--- a/src/main/resources/templates/fragments/sharing_metadata.html
+++ b/src/main/resources/templates/fragments/sharing_metadata.html
@@ -5,8 +5,20 @@
   <body>
 
   <th:block th:fragment="twitterAndOG">
-    <meta name="twitter:card" th:if="${twitterSiteHandle}" content="summary" />
+    <meta name="twitter:card" th:if="${twitterSiteHandle}" content="summary_large_image" />
     <meta name="twitter:site" th:if="${twitterSiteHandle}" th:content="${twitterSiteHandle}" />
+    <meta name="twitter:title" th:if="${title}"
+          th:content="${title}"
+          content="Naval affairs of England - BSB Cod.angl. 2"/>
+    <meta name="twitter:description" th:if="${description}"
+          th:content="${description}"
+          content="Dieser Prachteinband der ottonischen Epoche zählt zu den weltweit bedeutendsten Exemplaren; als Spolien wurden unter anderem eine karolingische Elfenbeintafel, mittelbyzantinische sowie ottonische Emails verwendet. // Karl-Georg Pfändtner"/>
+    <meta name="twitter:image" th:if="${preview}"
+          th:content ="${preview}"
+          content="https://api.digitale-sammlungen.de/iiif/image/v2/bsb00110131_00011/full/full/0/default.jpg"/>
+    <meta property="twitter:image:alt" th:if="${preview != null and title != null}"
+          th:content="${title}"
+          content="Naval affairs of England - BSB Cod.angl. 2"/>
 
     <meta property="og:image" th:if="${preview}"
           th:content ="${preview}"
@@ -25,7 +37,7 @@
           content="Naval affairs of England - BSB Cod.angl. 2"/>
     <meta property="og:description" th:if="${description}"
           th:content="${description}"
-          content="Sammelhandschrift"/>
+          content="Dieser Prachteinband der ottonischen Epoche zählt zu den weltweit bedeutendsten Exemplaren; als Spolien wurden unter anderem eine karolingische Elfenbeintafel, mittelbyzantinische sowie ottonische Emails verwendet. // Karl-Georg Pfändtner"/>
     <meta property="og:url" th:content="${#httpServletRequest.requestURL}" content="https://app.digitale-sammlungen.de/bookshelf/bsb00110131/view" />
     <meta property="og:type" content="website">
 

--- a/src/main/resources/templates/fragments/sharing_metadata.html
+++ b/src/main/resources/templates/fragments/sharing_metadata.html
@@ -11,6 +11,9 @@
     <meta property="og:image" th:if="${preview}"
           th:content ="${preview}"
           content="https://api.digitale-sammlungen.de/iiif/image/v2/bsb00110131_00011/full/full/0/default.jpg"/>
+    <meta property="og:image:alt" th:if="${preview != null and title != null}"
+          th:content="${title}"
+          content="Naval affairs of England - BSB Cod.angl. 2"/>
     <meta property="og:image:width" th:if="${previewWidth}"
           th:content="${previewWidth}"
           content="4683"/>
@@ -23,6 +26,9 @@
     <meta property="og:description" th:if="${description}"
           th:content="${description}"
           content="Sammelhandschrift"/>
+    <meta property="og:url" th:content="${#httpServletRequest.requestURL}" content="https://app.digitale-sammlungen.de/bookshelf/bsb00110131/view" />
+    <meta property="og:type" content="website">
+
   </th:block>
 
   <th:block th:fragment="twitterCards">


### PR DESCRIPTION
The description field now respects localization. Adds OpenGrap tags  for URL, image alt-text and mandatory type. Adds all tags needed to get Twitter Summary Cards with large image.