### PR TITLE
Add auto-formatting via google style

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 
     <!-- plugins -->
     <version.jacoco-maven-plugin>0.8.5</version.jacoco-maven-plugin>
-    <version.maven-checkstyle-plugin>3.0.0</version.maven-checkstyle-plugin>
+    <version.maven-fmt-plugin>2.9</version.maven-fmt-plugin>
     <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
     <version.maven-surefire-plugin>3.0.0-M4</version.maven-surefire-plugin>
     <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
@@ -355,6 +355,18 @@
 
     <plugins>
       <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>${version.maven-fmt-plugin}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>format</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${version.spotbugs-maven-plugin}</version>
@@ -368,27 +380,6 @@
         </dependencies>
         <executions>
           <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>${version.maven-checkstyle-plugin}</version>
-        <executions>
-          <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <configuration>
-              <configLocation>https://raw.githubusercontent.com/dbmdz/development/master/code-quality/checkstyle.xml</configLocation>
-              <encoding>UTF-8</encoding>
-              <consoleOutput>true</consoleOutput>
-              <failsOnError>true</failsOnError>
-              <linkXRef>false</linkXRef>
-            </configuration>
             <goals>
               <goal>check</goal>
             </goals>

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/backend/api/repository/IiifManifestSummaryRepository.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/backend/api/repository/IiifManifestSummaryRepository.java
@@ -10,16 +10,16 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.core.query.TextCriteria;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-/**
- * Repository for IiifManifestSummaries identified by the manifest URI.
- */
-public interface IiifManifestSummaryRepository extends MongoRepository<IiifManifestSummary, UUID>, IiifManifestSummaryRepositoryCustom {
+/** Repository for IiifManifestSummaries identified by the manifest URI. */
+public interface IiifManifestSummaryRepository
+    extends MongoRepository<IiifManifestSummary, UUID>, IiifManifestSummaryRepositoryCustom {
 
   public List<IiifManifestSummary> findAllByOrderByLastModifiedDesc();
 
   public Page<IiifManifestSummary> findAllByOrderByLastModifiedDesc(Pageable pageRequest);
 
-  public Page<IiifManifestSummary> findBy(TextCriteria criteria, Pageable page); // do not expose mongo TextCriteria to service layer!
+  public Page<IiifManifestSummary> findBy(
+      TextCriteria criteria, Pageable page); // do not expose mongo TextCriteria to service layer!
 
   public IiifManifestSummary findByManifestUri(String manifestUri);
 

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/backend/api/repository/IiifManifestSummarySearchRepository.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/backend/api/repository/IiifManifestSummarySearchRepository.java
@@ -9,7 +9,8 @@ public interface IiifManifestSummarySearchRepository<T> {
 
   public Iterable<T> findBy(String text, int start, int rows);
 
-  public Page<IiifManifestSummary> findBy(String text, Pageable pageable) throws SearchSyntaxException;
+  public Page<IiifManifestSummary> findBy(String text, Pageable pageable)
+      throws SearchSyntaxException;
 
   public Iterable<T> findBy(String text);
 

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/backend/impl/repository/IiifManifestSummaryRepositoryImplMongo.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/backend/impl/repository/IiifManifestSummaryRepositoryImplMongo.java
@@ -13,13 +13,13 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class IiifManifestSummaryRepositoryImplMongo implements IiifManifestSummaryRepositoryCustom {
 
-  @Autowired
-  IiifManifestSummaryRepository repo;
+  @Autowired IiifManifestSummaryRepository repo;
 
   @PostConstruct
   public void ensureTextIndex() {
     // make sure the index is set up properly (not yet possible via Spring Data Annotations)
-    // mongoOperations.getCollection("iiif-manifest-summaries").ensureIndex(new BasicDBObject("description", "text"));
+    // mongoOperations.getCollection("iiif-manifest-summaries").ensureIndex(new
+    // BasicDBObject("description", "text"));
   }
 
   @Override
@@ -28,7 +28,8 @@ public class IiifManifestSummaryRepositoryImplMongo implements IiifManifestSumma
     textCriteria.matchingAny(text);
     // TextCriteria textCriteria = TextCriteria.forDefaultLanguage().matchingAny(text);
     // Query query = TextQuery.queryText(textCriteria).sortByScore();
-    // DBCursor find = mongoOperations.getCollection("iiif-manifest-summaries").find(query.getQueryObject());
+    // DBCursor find =
+    // mongoOperations.getCollection("iiif-manifest-summaries").find(query.getQueryObject());
     return repo.findBy(textCriteria, page);
 
     // List<IiifManifestSummary> find = mongoTemplate.find(query, IiifManifestSummary.class);

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/backend/impl/repository/IiifManifestSummarySearchRepositoryImplSolrj.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/backend/impl/repository/IiifManifestSummarySearchRepositoryImplSolrj.java
@@ -29,15 +29,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class IiifManifestSummarySearchRepositoryImplSolrj implements IiifManifestSummarySearchRepository<UUID> {
+public class IiifManifestSummarySearchRepositoryImplSolrj
+    implements IiifManifestSummarySearchRepository<UUID> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(IiifManifestSummarySearchRepositoryImplSolrj.class);
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(IiifManifestSummarySearchRepositoryImplSolrj.class);
 
-  @Autowired
-  private IiifManifestSummaryRepository iiifManifestSummaryRepository;
+  @Autowired private IiifManifestSummaryRepository iiifManifestSummaryRepository;
 
-  @Autowired
-  private SolrClient solr;
+  @Autowired private SolrClient solr;
 
   @Value("${custom.solr.collection}")
   private String collection;
@@ -76,14 +76,14 @@ public class IiifManifestSummarySearchRepositoryImplSolrj implements IiifManifes
       }
       rs = response.getResults();
       numFound = rs.getNumFound();
-
     }
     LOGGER.info("--------------------------------------------------Results: " + rs.size());
     return getUUIDs(rs);
   }
 
   @Override
-  public Page<IiifManifestSummary> findBy(String text, Pageable pageable) throws SearchSyntaxException {
+  public Page<IiifManifestSummary> findBy(String text, Pageable pageable)
+      throws SearchSyntaxException {
     // läuft hier rein!!
     SolrQuery query = buildSolrQuery(text, (int) pageable.getOffset());
     query.setRows(pageable.getPageSize());
@@ -144,7 +144,8 @@ public class IiifManifestSummarySearchRepositoryImplSolrj implements IiifManifes
     doc.addField("id", manifestSummary.getUuid().toString());
     doc.addField("manifesturi_keu", manifestSummary.getManifestUri());
     String[] uri = manifestSummary.getManifestUri().split("/");
-    // FIXME: just works with recommended url pattern (see http://iiif.io/api/presentation/2.1/#a-summary-of-recommended-uri-patterns)
+    // FIXME: just works with recommended url pattern (see
+    // http://iiif.io/api/presentation/2.1/#a-summary-of-recommended-uri-patterns)
     doc.addField("identifier_str", uri[uri.length - 2]);
 
     for (Entry<Locale, String> e : manifestSummary.getLabels().entrySet()) {
@@ -187,7 +188,11 @@ public class IiifManifestSummarySearchRepositoryImplSolrj implements IiifManifes
   protected String escapeUnwantedSpecialChars(String text) {
     // We don't want to escape whitespaces, * and "
     // But we want to escape all the ohter special characters
-    return ClientUtils.escapeQueryChars(text).replaceAll("\\\\\\*", "*").replaceAll("\\\\\\?", "?").replaceAll("\\\\\\s", " ").replaceAll("\\\\\\\"", "\"");
+    return ClientUtils.escapeQueryChars(text)
+        .replaceAll("\\\\\\*", "*")
+        .replaceAll("\\\\\\?", "?")
+        .replaceAll("\\\\\\s", " ")
+        .replaceAll("\\\\\\\"", "\"");
   }
 
   private SolrQuery buildSolrQuery(String text, int start) {

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/business/api/service/IiifManifestSummaryService.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/business/api/service/IiifManifestSummaryService.java
@@ -11,19 +11,18 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-/**
- *
- * @author ralf
- */
+/** @author ralf */
 public interface IiifManifestSummaryService {
 
   public IiifManifestSummary add(IiifManifestSummary manifest);
 
   public long countAll();
 
-  public void enrichAndSave(IiifManifestSummary manifestSummary) throws URISyntaxException, NotFoundException, IOException;
+  public void enrichAndSave(IiifManifestSummary manifestSummary)
+      throws URISyntaxException, NotFoundException, IOException;
 
-  public Page<IiifManifestSummary> findAll(String searchText, Pageable pageable) throws SearchSyntaxException;
+  public Page<IiifManifestSummary> findAll(String searchText, Pageable pageable)
+      throws SearchSyntaxException;
 
   public IiifManifestSummary get(UUID uuid);
 

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/business/impl/service/AbstractManifestParser.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/business/impl/service/AbstractManifestParser.java
@@ -29,11 +29,9 @@ public abstract class AbstractManifestParser {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractManifestParser.class);
 
-  @Autowired
-  private ApplicationContext appContext;
+  @Autowired private ApplicationContext appContext;
 
-  @Autowired
-  private ObjectMapper objectMapper;
+  @Autowired private ObjectMapper objectMapper;
 
   @Value("${custom.summary.thumbnail.width}")
   private int thumbnailWidth;
@@ -43,7 +41,8 @@ public abstract class AbstractManifestParser {
       try {
         Resource springResource = appContext.getResource(serviceUrl + "/info.json");
         // get info.json for available sizes
-        ImageService imageServiceExternal = (ImageService) objectMapper.readValue(springResource.getInputStream(), Service.class);
+        ImageService imageServiceExternal =
+            (ImageService) objectMapper.readValue(springResource.getInputStream(), Service.class);
         sizes = imageServiceExternal.getSizes();
       } catch (IOException ex) {
         LOGGER.debug("Can not read info.json", ex);
@@ -51,12 +50,16 @@ public abstract class AbstractManifestParser {
     }
     int bestWidth = thumbnailWidth;
     if (sizes != null) {
-      bestWidth = sizes.stream()
+      bestWidth =
+          sizes.stream()
               .filter(s -> s.getWidth() >= thumbnailWidth)
               .sorted(Comparator.comparing(s -> Math.abs(thumbnailWidth - s.getWidth())))
-              .map(Size::getWidth).findFirst().orElse(thumbnailWidth);
+              .map(Size::getWidth)
+              .findFirst()
+              .orElse(thumbnailWidth);
     }
-    // TODO add check, if minimal width is met (make minWidth configurable), otherwise get second best width...
+    // TODO add check, if minimal width is met (make minWidth configurable), otherwise get second
+    // best width...
     String thumbnailUrl = String.format("%s/full/%d,/0/", serviceUrl, bestWidth);
     if (isV1) {
       thumbnailUrl += "native.jpg";
@@ -84,11 +87,13 @@ public abstract class AbstractManifestParser {
     return thumbnail;
   }
 
-  protected InputStream getContentInputStream(String uri) throws URISyntaxException, UnsupportedOperationException, IOException {
+  protected InputStream getContentInputStream(String uri)
+      throws URISyntaxException, UnsupportedOperationException, IOException {
     return getContentInputStream(new URI(uri));
   }
 
-  protected InputStream getContentInputStream(URI uri) throws UnsupportedOperationException, IOException {
+  protected InputStream getContentInputStream(URI uri)
+      throws UnsupportedOperationException, IOException {
     HttpClient httpClient = HttpClientBuilder.create().build();
     HttpGet httpGet = new HttpGet(uri);
     HttpResponse response = httpClient.execute(httpGet);
@@ -96,5 +101,6 @@ public abstract class AbstractManifestParser {
     return content;
   }
 
-  public abstract void fillSummary(IiifManifestSummary manifestSummary) throws IOException, URISyntaxException;
+  public abstract void fillSummary(IiifManifestSummary manifestSummary)
+      throws IOException, URISyntaxException;
 }

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/business/impl/service/GraciousManifestParser.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/business/impl/service/GraciousManifestParser.java
@@ -30,7 +30,8 @@ public class GraciousManifestParser extends AbstractManifestParser {
   public static final Locale DEFAULT_LOCALE = Locale.GERMAN;
 
   @Override
-  public void fillSummary(IiifManifestSummary manifestSummary) throws IOException, URISyntaxException {
+  public void fillSummary(IiifManifestSummary manifestSummary)
+      throws IOException, URISyntaxException {
     final InputStream is;
     try {
       is = getContentInputStream(manifestSummary.getManifestUri());
@@ -40,10 +41,12 @@ public class GraciousManifestParser extends AbstractManifestParser {
     fillFromInputStream(is, manifestSummary);
   }
 
-  protected void fillFromInputStream(final InputStream is, IiifManifestSummary manifestSummary) throws IOException {
+  protected void fillFromInputStream(final InputStream is, IiifManifestSummary manifestSummary)
+      throws IOException {
     try {
       JSONParser jsonParser = new JSONParser();
-      JSONObject jsonObject = (JSONObject) jsonParser.parse(new InputStreamReader(is, StandardCharsets.UTF_8));
+      JSONObject jsonObject =
+          (JSONObject) jsonParser.parse(new InputStreamReader(is, StandardCharsets.UTF_8));
 
       fillFromJsonObject(jsonObject, manifestSummary);
     } catch (ParseException ex) {
@@ -53,13 +56,12 @@ public class GraciousManifestParser extends AbstractManifestParser {
   }
 
   /**
-   * Language may be associated with strings that are intended to be displayed to the user with the following pattern of
+   * Language may be associated with strings that are intended to be displayed to the user with the
+   * following pattern of
    *
    * @value plus the RFC 5646 code in
-   *
-   *        @language, instead of a plain string. This pattern may be used in label, description, attribution and the
-   *        label and value fields of the metadata construction.
-   *
+   * @language, instead of a plain string. This pattern may be used in label, description,
+   *     attribution and the label and value fields of the metadata construction.
    * @param manifestSummary manifest summary as target
    */
   private void fillFromJsonObject(JSONObject jsonObject, IiifManifestSummary manifestSummary) {
@@ -120,7 +122,8 @@ public class GraciousManifestParser extends AbstractManifestParser {
 
     JSONObject firstSequence = null;
     if (thumbnailObj == null) {
-      // A sequence may have one or more thumbnails and should have at least one thumbnail if there are multiple sequences in a single manifest.
+      // A sequence may have one or more thumbnails and should have at least one thumbnail if there
+      // are multiple sequences in a single manifest.
       JSONArray sequencesArray = (JSONArray) manifestObj.get("sequences");
       if (sequencesArray != null) {
         firstSequence = (JSONObject) sequencesArray.get(0);
@@ -132,13 +135,16 @@ public class GraciousManifestParser extends AbstractManifestParser {
 
     JSONArray canvases = null;
     if (thumbnailObj == null && firstSequence != null) {
-      // A canvas may have one or more thumbnails and should have at least one thumbnail if there are multiple images or resources that make up the representation.
+      // A canvas may have one or more thumbnails and should have at least one thumbnail if there
+      // are multiple images or resources that make up the representation.
       canvases = (JSONArray) firstSequence.get("canvases");
       if (canvases != null) {
-        Object obj = canvases.stream()
+        Object obj =
+            canvases.stream()
                 .map(c -> ((JSONObject) c).get("thumbnail"))
                 .filter(t -> t != null)
-                .findFirst().orElse(null);
+                .findFirst()
+                .orElse(null);
         if (obj != null) {
           if (obj instanceof JSONObject) {
             thumbnailObj = (JSONObject) obj;
@@ -154,9 +160,8 @@ public class GraciousManifestParser extends AbstractManifestParser {
       if (firstCanvas != null) {
         JSONArray images = (JSONArray) firstCanvas.get("images");
         if (images != null) {
-          Object obj = images.stream()
-                  .map(i -> ((JSONObject) i).get("resource"))
-                  .findFirst().orElse(null);
+          Object obj =
+              images.stream().map(i -> ((JSONObject) i).get("resource")).findFirst().orElse(null);
           if (obj != null) {
             if (obj instanceof JSONObject) {
               thumbnailObj = (JSONObject) obj;

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/business/impl/service/IiifCollectionServiceImpl.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/business/impl/service/IiifCollectionServiceImpl.java
@@ -18,14 +18,13 @@ public class IiifCollectionServiceImpl implements IiifCollectionService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IiifCollectionServiceImpl.class);
 
-  @Autowired
-  private IiifManifestSummaryService iiifManifestSummaryService;
+  @Autowired private IiifManifestSummaryService iiifManifestSummaryService;
 
-  @Autowired
-  private StrictCollectionParser strictCollectionParser;
+  @Autowired private StrictCollectionParser strictCollectionParser;
 
   @Override
-  public void importAllObjects(IiifManifestSummary manifestSummary) throws URISyntaxException, IOException {
+  public void importAllObjects(IiifManifestSummary manifestSummary)
+      throws URISyntaxException, IOException {
     Collection collection = strictCollectionParser.parse(manifestSummary.getManifestUri());
     saveManifestsFromCollection(collection);
   }
@@ -36,7 +35,11 @@ public class IiifCollectionServiceImpl implements IiifCollectionService {
 
     int manifestsCount = (manifests != null) ? manifests.size() : -1;
     int subCollectionsCount = (subCollections != null) ? subCollections.size() : -1;
-    LOGGER.info("Processing collection '{}' with {} manifests and {} sub collections.", collection.getIdentifier().toString(), manifestsCount, subCollectionsCount);
+    LOGGER.info(
+        "Processing collection '{}' with {} manifests and {} sub collections.",
+        collection.getIdentifier().toString(),
+        manifestsCount,
+        subCollectionsCount);
 
     // try to get list of manifests
     if (manifests != null) {
@@ -49,7 +52,8 @@ public class IiifCollectionServiceImpl implements IiifCollectionService {
         try {
           iiifManifestSummaryService.enrichAndSave(summary);
         } catch (Exception e) {
-          LOGGER.warn("Could not read manifest from {} because of error {}", manifestUri, e.getMessage());
+          LOGGER.warn(
+              "Could not read manifest from {} because of error {}", manifestUri, e.getMessage());
         }
       }
     }
@@ -62,7 +66,10 @@ public class IiifCollectionServiceImpl implements IiifCollectionService {
           subCollection = strictCollectionParser.parse(subCollectionIdentifier);
           saveManifestsFromCollection(subCollection);
         } catch (Exception e) {
-          LOGGER.warn("Could not read collection from {} because of error {}", subCollectionIdentifier, e.getMessage());
+          LOGGER.warn(
+              "Could not read collection from {} because of error {}",
+              subCollectionIdentifier,
+              e.getMessage());
         }
       }
     }

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/business/impl/service/StrictCollectionParser.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/business/impl/service/StrictCollectionParser.java
@@ -12,11 +12,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class StrictCollectionParser extends AbstractManifestParser {
 
-  @Autowired
-  private ObjectMapper objectMapper;
+  @Autowired private ObjectMapper objectMapper;
 
   @Override
-  public void fillSummary(IiifManifestSummary manifestSummary) throws IOException, URISyntaxException {
+  public void fillSummary(IiifManifestSummary manifestSummary)
+      throws IOException, URISyntaxException {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/business/impl/service/StrictManifestParser.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/business/impl/service/StrictManifestParser.java
@@ -29,11 +29,11 @@ public class StrictManifestParser extends AbstractManifestParser {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(StrictManifestParser.class);
 
-  @Autowired
-  private ObjectMapper objectMapper;
+  @Autowired private ObjectMapper objectMapper;
 
   @Override
-  public void fillSummary(IiifManifestSummary manifestSummary) throws IOException, URISyntaxException {
+  public void fillSummary(IiifManifestSummary manifestSummary)
+      throws IOException, URISyntaxException {
     final InputStream is;
     try {
       is = getContentInputStream(manifestSummary.getManifestUri());
@@ -45,12 +45,15 @@ public class StrictManifestParser extends AbstractManifestParser {
   }
 
   /**
-   * Language may be associated with strings that are intended to be displayed to the user with the following pattern of
-   * &#64;value plus the RFC 5646 code in &#64;language, instead of a plain string. This pattern may be used in label,
-   * description, attribution and the label and value fields of the metadata construction.
+   * Language may be associated with strings that are intended to be displayed to the user with the
+   * following pattern of &#64;value plus the RFC 5646 code in &#64;language, instead of a plain
+   * string. This pattern may be used in label, description, attribution and the label and value
+   * fields of the metadata construction.
    */
-  private void fillFromManifest(Manifest manifest, IiifManifestSummary manifestSummary) throws NotFoundException {
-    // set from "@id" value to avoid using slightly different http-urls (e.g. with or without request params) pointing to same manifest
+  private void fillFromManifest(Manifest manifest, IiifManifestSummary manifestSummary)
+      throws NotFoundException {
+    // set from "@id" value to avoid using slightly different http-urls (e.g. with or without
+    // request params) pointing to same manifest
     manifestSummary.setManifestUri(manifest.getIdentifier().toString());
     manifestSummary.setLabels(getLocalizedStrings(manifest.getLabel()));
     manifestSummary.setDescriptions(getLocalizedStrings(manifest.getDescription()));
@@ -78,12 +81,13 @@ public class StrictManifestParser extends AbstractManifestParser {
   }
 
   /**
-   * Thumbnail: "A small image that depicts or pictorially represents the resource that the property is attached to, such as the title page,
-   * a significant image or rendering of a canvas with multiple content resources associated with it.
-   * It is recommended that a IIIF Image API service be available for this image for manipulations such as resizing.
-   * If a resource has multiple thumbnails, then each of them should be different."
+   * Thumbnail: "A small image that depicts or pictorially represents the resource that the property
+   * is attached to, such as the title page, a significant image or rendering of a canvas with
+   * multiple content resources associated with it. It is recommended that a IIIF Image API service
+   * be available for this image for manipulations such as resizing. If a resource has multiple
+   * thumbnails, then each of them should be different."
    *
-   * see http://iiif.io/api/presentation/2.1/#thumbnail
+   * <p>see http://iiif.io/api/presentation/2.1/#thumbnail
    *
    * @param manifest iiif manifest
    * @return thumbnail representing this manifest's object
@@ -104,40 +108,50 @@ public class StrictManifestParser extends AbstractManifestParser {
     }
 
     if (imageContent == null && manifest.getDefaultSequence() != null) {
-      // A sequence may have one or more thumbnails and should have at least one thumbnail if there are multiple sequences in a single manifest.
+      // A sequence may have one or more thumbnails and should have at least one thumbnail if there
+      // are multiple sequences in a single manifest.
       imageContent = manifest.getDefaultSequence().getThumbnail();
     }
 
-    if (imageContent == null && manifest.getDefaultSequence() != null && manifest.getDefaultSequence().getCanvases() != null) {
-      // A canvas may have one or more thumbnails and should have at least one thumbnail if there are multiple images or resources that make up the representation.
-      imageContent = manifest.getDefaultSequence().getCanvases().stream()
+    if (imageContent == null
+        && manifest.getDefaultSequence() != null
+        && manifest.getDefaultSequence().getCanvases() != null) {
+      // A canvas may have one or more thumbnails and should have at least one thumbnail if there
+      // are multiple images or resources that make up the representation.
+      imageContent =
+          manifest.getDefaultSequence().getCanvases().stream()
               .map(c -> c.getThumbnails())
               .filter(ts -> ts != null && ts.size() > 0)
               .map(ts -> ts.get(0))
-              .findFirst().orElse(null);
-
+              .findFirst()
+              .orElse(null);
     }
 
     if (imageContent == null) {
       // No thumbnail found, yet. Take the first image of first canvas as "thumbnail".
-      imageContent = manifest.getDefaultSequence().getCanvases().get(0).getImages().stream()
+      imageContent =
+          manifest.getDefaultSequence().getCanvases().get(0).getImages().stream()
               .map(Annotation::getResource)
               .filter(ImageContent.class::isInstance)
               .map(ImageContent.class::cast)
-              .findFirst().orElse(null);
+              .findFirst()
+              .orElse(null);
     }
 
     if (imageContent != null) {
       // thumbnail candidate found
       ImageService imageService = null;
       if (imageContent.getServices() != null) {
-        imageService = imageContent.getServices().stream()
+        imageService =
+            imageContent.getServices().stream()
                 .filter(ImageService.class::isInstance)
                 .map(ImageService.class::cast)
-                .findFirst().orElse(null);
+                .findFirst()
+                .orElse(null);
       }
       if (imageService != null) {
-        boolean isV1 = imageService.getProfiles().stream()
+        boolean isV1 =
+            imageService.getProfiles().stream()
                 .map(p -> p.getIdentifier().toString())
                 .anyMatch(ImageApiProfile.V1_PROFILES::contains);
 

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/config/SharingConfig.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/config/SharingConfig.java
@@ -18,8 +18,7 @@ public class SharingConfig {
       @Value("${custom.sharing.previewImage.url:#{null}}") String previewImageUrl,
       @Value("${custom.sharing.previewImage.width:#{null}}") String previewImageWidth,
       @Value("${custom.sharing.previewImage.height:#{null}}") String previewImageHeight,
-      @Value("${custom.sharing.twitter.siteHandle:#{null}}") String twitterSiteHandle
-  ) {
+      @Value("${custom.sharing.twitter.siteHandle:#{null}}") String twitterSiteHandle) {
     this.previewImageUrl = previewImageUrl;
     if (previewImageHeight != null) {
       this.previewImageHeight = Integer.parseInt(previewImageHeight);
@@ -46,5 +45,4 @@ public class SharingConfig {
   public String getTwitterSiteHandle() {
     return twitterSiteHandle;
   }
-
 }

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/config/SpringConfig.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/config/SpringConfig.java
@@ -5,16 +5,15 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Configuration
-@ComponentScan(basePackages = {
-  "de.digitalcollections.commons.springboot.actuator",
-  "de.digitalcollections.commons.springboot.contributor",
-  "de.digitalcollections.commons.springboot.monitoring"
-})
+@ComponentScan(
+    basePackages = {
+      "de.digitalcollections.commons.springboot.actuator",
+      "de.digitalcollections.commons.springboot.contributor",
+      "de.digitalcollections.commons.springboot.monitoring"
+    })
 @Import({
   SpringConfigBackend.class, SpringConfigBusiness.class,
   SpringConfigSecurityMonitoring.class, SpringConfigSecurityWebapp.class,
   SpringConfigWeb.class
 })
-public class SpringConfig {
-
-}
+public class SpringConfig {}

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/config/SpringConfigBackend.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/config/SpringConfigBackend.java
@@ -25,14 +25,14 @@ import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 @Configuration
-@ComponentScan(basePackages = {
-  "de.digitalcollections.iiif.bookshelf.backend.api.repository",
-  "de.digitalcollections.iiif.bookshelf.backend.impl.repository"
-})
-@EnableAutoConfiguration(exclude = {
-  SolrAutoConfiguration.class
-})
-@EnableMongoRepositories(basePackages = {"de.digitalcollections.iiif.bookshelf.backend.api.repository"})
+@ComponentScan(
+    basePackages = {
+      "de.digitalcollections.iiif.bookshelf.backend.api.repository",
+      "de.digitalcollections.iiif.bookshelf.backend.impl.repository"
+    })
+@EnableAutoConfiguration(exclude = {SolrAutoConfiguration.class})
+@EnableMongoRepositories(
+    basePackages = {"de.digitalcollections.iiif.bookshelf.backend.api.repository"})
 @EnableMongoAuditing
 public class SpringConfigBackend {
 
@@ -79,7 +79,13 @@ public class SpringConfigBackend {
     try {
       SolrPing ping = new SolrPing();
       SolrPingResponse response = ping.process(client, collection);
-      LOGGER.info("State of solr ping request to " + solrServerAddress + "/" + collection + ": " + response.getStatus());
+      LOGGER.info(
+          "State of solr ping request to "
+              + solrServerAddress
+              + "/"
+              + collection
+              + ": "
+              + response.getStatus());
     } catch (IOException | SolrServerException e) {
       LOGGER.error("Cannot connect to " + solrServerAddress + ": " + e, e);
     }

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/config/SpringConfigBusiness.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/config/SpringConfigBusiness.java
@@ -4,9 +4,5 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan(basePackages = {
-  "de.digitalcollections.iiif.bookshelf.business.impl.service"
-})
-public class SpringConfigBusiness {
-
-}
+@ComponentScan(basePackages = {"de.digitalcollections.iiif.bookshelf.business.impl.service"})
+public class SpringConfigBusiness {}

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/config/SpringConfigSecurityMonitoring.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/config/SpringConfigSecurityMonitoring.java
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -25,18 +24,26 @@ public class SpringConfigSecurityMonitoring extends WebSecurityConfigurerAdapter
 
   @Override
   protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-    auth.inMemoryAuthentication().passwordEncoder(passwordEncoderDummy())
-      .withUser(User.withUsername(actuatorUsername).password(actuatorPassword).roles("ACTUATOR"));
+    auth.inMemoryAuthentication()
+        .passwordEncoder(passwordEncoderDummy())
+        .withUser(User.withUsername(actuatorUsername).password(actuatorPassword).roles("ACTUATOR"));
   }
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {
     // Monitoring:
-    // see https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-endpoints
-    http.antMatcher("/monitoring/**").authorizeRequests()
-      .requestMatchers(EndpointRequest.to(InfoEndpoint.class, HealthEndpoint.class)).permitAll()
-      .requestMatchers(EndpointRequest.to("prometheus", "version")).permitAll()
-      .requestMatchers(EndpointRequest.toAnyEndpoint()).hasRole("ACTUATOR").and().httpBasic();
+    // see
+    // https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-endpoints
+    http.antMatcher("/monitoring/**")
+        .authorizeRequests()
+        .requestMatchers(EndpointRequest.to(InfoEndpoint.class, HealthEndpoint.class))
+        .permitAll()
+        .requestMatchers(EndpointRequest.to("prometheus", "version"))
+        .permitAll()
+        .requestMatchers(EndpointRequest.toAnyEndpoint())
+        .hasRole("ACTUATOR")
+        .and()
+        .httpBasic();
   }
 
   private PasswordEncoder passwordEncoderDummy() {

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/config/SpringConfigSecurityWebapp.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/config/SpringConfigSecurityWebapp.java
@@ -26,15 +26,17 @@ public class SpringConfigSecurityWebapp extends WebSecurityConfigurerAdapter {
   @Override
   protected void configure(AuthenticationManagerBuilder auth) throws Exception {
     if (isAuthenticationEnabled) {
-      auth.inMemoryAuthentication().passwordEncoder(passwordEncoderDummy()).withUser(
-        User.withUsername(username).password(password).roles("USER")
-      );
+      auth.inMemoryAuthentication()
+          .passwordEncoder(passwordEncoderDummy())
+          .withUser(User.withUsername(username).password(password).roles("USER"));
     }
   }
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {
-    http.authorizeRequests().requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll();
+    http.authorizeRequests()
+        .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
+        .permitAll();
     http.headers().frameOptions().disable(); // to make universalviewer work
     /* Refused to display 'http://localhost:8080/webjars/universalviewer/2.0.2/dist/uv-2.0.2/app.html?isHomeDomain=true&isOnlyInstance=true&manifestUri=https%3A%2F%2Fapi.digitale-sammlungen.de%2Fiiif%2Fpresentation%2Fv2%2Fbsb00010484_00505_u001%2Fmanifest&embedScriptUri=http://localhost:8080/webjars/universalviewer/2.0.2/dist/uv-2.0.2/lib/embed.js&embedDomain=localhost&domain=localhost&isLightbox=false&locale=en-GB&xdm_e=http%3A%2F%2Flocalhost%3A8080%2Fuv%2F1FC1F766&xdm_c=default127&xdm_p=4' in a frame because it set 'X-Frame-Options' to 'deny'. */
     if (!isAuthenticationEnabled) {
@@ -42,8 +44,20 @@ public class SpringConfigSecurityWebapp extends WebSecurityConfigurerAdapter {
       return;
     }
 
-    http.authorizeRequests().antMatchers("/add*").authenticated().and().formLogin().loginPage("/login"); // enable form based log in
-    http.authorizeRequests().antMatchers("/api/**").authenticated().and().httpBasic().and().csrf().disable(); // enable basic auth for api
+    http.authorizeRequests()
+        .antMatchers("/add*")
+        .authenticated()
+        .and()
+        .formLogin()
+        .loginPage("/login"); // enable form based log in
+    http.authorizeRequests()
+        .antMatchers("/api/**")
+        .authenticated()
+        .and()
+        .httpBasic()
+        .and()
+        .csrf()
+        .disable(); // enable basic auth for api
   }
 
   private PasswordEncoder passwordEncoderDummy() {

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/config/SpringConfigWeb.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/config/SpringConfigWeb.java
@@ -27,8 +27,13 @@ public class SpringConfigWeb implements WebMvcConfigurer {
 
   @Override
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
-    registry.addResourceHandler("/favicon.ico").addResourceLocations("classpath:/static/images/favicon.png");
-    registry.addResourceHandler("/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/").setCachePeriod(Integer.MAX_VALUE);
+    registry
+        .addResourceHandler("/favicon.ico")
+        .addResourceLocations("classpath:/static/images/favicon.png");
+    registry
+        .addResourceHandler("/webjars/**")
+        .addResourceLocations("classpath:/META-INF/resources/webjars/")
+        .setCachePeriod(Integer.MAX_VALUE);
   }
 
   @Bean
@@ -42,7 +47,8 @@ public class SpringConfigWeb implements WebMvcConfigurer {
     localeChangeInterceptor.setParamName("language");
     registry.addInterceptor(localeChangeInterceptor);
 
-    CurrentUrlAsModelAttributeHandlerInterceptor currentUrlAsModelAttributeHandlerInterceptor = new CurrentUrlAsModelAttributeHandlerInterceptor();
+    CurrentUrlAsModelAttributeHandlerInterceptor currentUrlAsModelAttributeHandlerInterceptor =
+        new CurrentUrlAsModelAttributeHandlerInterceptor();
     currentUrlAsModelAttributeHandlerInterceptor.deleteParams("language");
     registry.addInterceptor(currentUrlAsModelAttributeHandlerInterceptor);
   }

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/frontend/controller/WebController.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/frontend/controller/WebController.java
@@ -52,8 +52,7 @@ public class WebController extends AbstractController {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(WebController.class);
 
-  @Autowired
-  private MessageSource messageSource;
+  @Autowired private MessageSource messageSource;
 
   @Autowired
   @Value("#{iiifVersions}")
@@ -62,17 +61,13 @@ public class WebController extends AbstractController {
   @Value("${custom.app.security.enabled}")
   private boolean authentication;
 
-  @Autowired
-  private IiifCollectionService iiifCollectionService;
+  @Autowired private IiifCollectionService iiifCollectionService;
 
-  @Autowired
-  private IiifManifestSummaryService iiifManifestSummaryService;
+  @Autowired private IiifManifestSummaryService iiifManifestSummaryService;
 
-  @Autowired
-  private ObjectMapper objectMapper;
+  @Autowired private ObjectMapper objectMapper;
 
-  @Autowired
-  private SharingConfig sharingConfig;
+  @Autowired private SharingConfig sharingConfig;
 
   /**
    * List with or without search query.
@@ -84,9 +79,15 @@ public class WebController extends AbstractController {
    * @param results validation results and errors
    * @return view of list of objects
    */
-  @RequestMapping(value = {"", "/"}, method = RequestMethod.GET)
-  public String list(SearchRequest searchRequest, Model model, Pageable pageRequest, @RequestParam(required = false,
-    defaultValue = "grid") String style, BindingResult results) {
+  @RequestMapping(
+      value = {"", "/"},
+      method = RequestMethod.GET)
+  public String list(
+      SearchRequest searchRequest,
+      Model model,
+      Pageable pageRequest,
+      @RequestParam(required = false, defaultValue = "grid") String style,
+      BindingResult results) {
     verifyBinding(results);
 
     model.addAttribute("authentication", authentication);
@@ -119,7 +120,10 @@ public class WebController extends AbstractController {
     try {
       iiifManifestSummaryService.enrichAndSave(manifestSummary);
     } catch (IOException e) {
-      LOGGER.warn("Could not load manifest from {} because of malformed JSON", manifestSummary.getManifestUri(), e);
+      LOGGER.warn(
+          "Could not load manifest from {} because of malformed JSON",
+          manifestSummary.getManifestUri(),
+          e);
       model.addAttribute("manifest", manifestSummary);
       model.addAttribute("errorMessage", "Manifest at URL contains malformed JSON.");
       return "add";
@@ -141,7 +145,9 @@ public class WebController extends AbstractController {
     } catch (Exception e) {
       LOGGER.warn("Could not add collection manifest from {}", manifestSummary.getManifestUri(), e);
       model.addAttribute("manifest", manifestSummary);
-      model.addAttribute("errorMessage", "Could not add collection manifest from " + manifestSummary.getManifestUri());
+      model.addAttribute(
+          "errorMessage",
+          "Could not add collection manifest from " + manifestSummary.getManifestUri());
       return "add";
     }
     return "redirect:/";
@@ -157,18 +163,23 @@ public class WebController extends AbstractController {
       return summary;
     } catch (IOException e) {
       LOGGER.warn("IOException for manifest at {}: ", manifestUri, e);
-      throw new ApiException("Invalid manifest at URL '" + manifestUri + "'", HttpStatus.BAD_REQUEST);
+      throw new ApiException(
+          "Invalid manifest at URL '" + manifestUri + "'", HttpStatus.BAD_REQUEST);
     } catch (NotFoundException | URISyntaxException e) {
       LOGGER.warn("Exception for manifest at {}: ", manifestUri, e);
       throw new ApiException("No manifest at URL '" + manifestUri + "'", HttpStatus.NOT_FOUND);
     } catch (Exception e) {
       LOGGER.warn("Exception for manifest at {}: ", manifestUri, e);
-      throw new ApiException("Exception for manifest at: '" + manifestUri + "'", HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new ApiException(
+          "Exception for manifest at: '" + manifestUri + "'", HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
   @ResponseBody
-  @RequestMapping(value = "/api/addCollection", method = RequestMethod.POST, produces = "application/json")
+  @RequestMapping(
+      value = "/api/addCollection",
+      method = RequestMethod.POST,
+      produces = "application/json")
   public boolean apiAddCollection(@RequestParam("uri") String manifestUri) throws ApiException {
     IiifManifestSummary summary = new IiifManifestSummary();
     summary.setManifestUri(manifestUri);
@@ -177,33 +188,41 @@ public class WebController extends AbstractController {
       return true;
     } catch (IOException e) {
       LOGGER.warn("IOException for collection at {}: ", manifestUri, e);
-      throw new ApiException("Invalid collection manifest at URL '" + manifestUri + "'", HttpStatus.BAD_REQUEST);
+      throw new ApiException(
+          "Invalid collection manifest at URL '" + manifestUri + "'", HttpStatus.BAD_REQUEST);
     } catch (URISyntaxException e) {
-      throw new ApiException("No collection manifest at URL '" + manifestUri + "'", HttpStatus.NOT_FOUND);
+      throw new ApiException(
+          "No collection manifest at URL '" + manifestUri + "'", HttpStatus.NOT_FOUND);
     } catch (Exception e) {
       LOGGER.warn("Exception for collection at {}: ", manifestUri, e);
-      throw new ApiException("Exception for collection at: '" + manifestUri + "'", HttpStatus.INTERNAL_SERVER_ERROR);
+      throw new ApiException(
+          "Exception for collection at: '" + manifestUri + "'", HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
 
-//  @CrossOrigin(origins = "*")
-//  @RequestMapping(value = {"/view/{uuid}"}, method = RequestMethod.GET)
-//  public String viewBook(@PathVariable UUID uuid, Model model) {
-//    IiifManifestSummary iiifManifestSummary = iiifManifestSummaryService.get(uuid);
-//    model.addAttribute("manifestId", iiifManifestSummary.getManifestUri());
-//    String title = iiifManifestSummaryService.getLabel(iiifManifestSummary, LocaleContextHolder.getLocale());
-//    model.addAttribute("title", title);
-//    return "mirador/view";
-//  }
+  //  @CrossOrigin(origins = "*")
+  //  @RequestMapping(value = {"/view/{uuid}"}, method = RequestMethod.GET)
+  //  public String viewBook(@PathVariable UUID uuid, Model model) {
+  //    IiifManifestSummary iiifManifestSummary = iiifManifestSummaryService.get(uuid);
+  //    model.addAttribute("manifestId", iiifManifestSummary.getManifestUri());
+  //    String title = iiifManifestSummaryService.getLabel(iiifManifestSummary,
+  // LocaleContextHolder.getLocale());
+  //    model.addAttribute("title", title);
+  //    return "mirador/view";
+  //  }
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = {"/view/{id}"}, method = RequestMethod.GET)
+  @RequestMapping(
+      value = {"/view/{id}"},
+      method = RequestMethod.GET)
   @Deprecated
   public String oldViewObject(@PathVariable String id, Model model) {
     return "redirect:/" + id + "/view";
   }
 
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = {"/{id}/view"}, method = RequestMethod.GET)
+  @RequestMapping(
+      value = {"/{id}/view"},
+      method = RequestMethod.GET)
   public String viewObject(@PathVariable String id, Model model, Locale locale) {
     String redirect = redirectUuidToViewId(id);
     if (redirect != null) {
@@ -215,7 +234,8 @@ public class WebController extends AbstractController {
     return "mirador/view";
   }
 
-  protected Pair<Manifest, IiifManifestSummary> fillModelWithObject(String id, Model model, Locale locale) {
+  protected Pair<Manifest, IiifManifestSummary> fillModelWithObject(
+      String id, Model model, Locale locale) {
     IiifManifestSummary iiifManifestSummary = iiifManifestSummaryService.get(id);
     if (iiifManifestSummary == null) {
       throw new NotFoundException();
@@ -223,7 +243,8 @@ public class WebController extends AbstractController {
     model.addAttribute("iiifVersions", iiifVersions);
     final String manifestUri = iiifManifestSummary.getManifestUri();
     model.addAttribute("manifestId", manifestUri);
-    String title = iiifManifestSummaryService.getLabel(iiifManifestSummary, LocaleContextHolder.getLocale());
+    String title =
+        iiifManifestSummaryService.getLabel(iiifManifestSummary, LocaleContextHolder.getLocale());
     model.addAttribute("title", title);
     model.addAttribute("ogTitle", title);
     model.addAttribute("manifestSummary", iiifManifestSummary);
@@ -246,14 +267,16 @@ public class WebController extends AbstractController {
 
       return Pair.of(manifest, iiifManifestSummary);
     } catch (IOException e) {
-      model.addAttribute("error_message", messageSource.getMessage("manifest_error", new Object[]{}, locale));
+      model.addAttribute(
+          "error_message", messageSource.getMessage("manifest_error", new Object[] {}, locale));
     }
     return null;
   }
 
-
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = {"/{id}/uv"}, method = RequestMethod.GET)
+  @RequestMapping(
+      value = {"/{id}/uv"},
+      method = RequestMethod.GET)
   public String viewObjectInUniversalViewer(@PathVariable String id, Model model, Locale locale) {
     String redirect = redirectUuidToViewId(id);
     if (redirect != null) {
@@ -266,15 +289,20 @@ public class WebController extends AbstractController {
   }
 
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = {"/info/{id}"}, method = RequestMethod.GET)
+  @RequestMapping(
+      value = {"/info/{id}"},
+      method = RequestMethod.GET)
   @Deprecated
   public String oldObjectInfo(@PathVariable String id, Model model) {
     return "redirect:/" + id;
   }
 
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = {"/{id}"}, method = RequestMethod.HEAD)
-  public void objectExists(@PathVariable String id, HttpServletResponse response) throws IOException {
+  @RequestMapping(
+      value = {"/{id}"},
+      method = RequestMethod.HEAD)
+  public void objectExists(@PathVariable String id, HttpServletResponse response)
+      throws IOException {
     IiifManifestSummary iiifManifestSummary;
 
     try {
@@ -292,7 +320,9 @@ public class WebController extends AbstractController {
   }
 
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = {"/{id}"}, method = RequestMethod.GET)
+  @RequestMapping(
+      value = {"/{id}"},
+      method = RequestMethod.GET)
   public String objectInfo(@PathVariable String id, Model model, Locale locale) throws IOException {
     String redirect = redirectUuidToViewId(id);
     if (redirect != null) {
@@ -327,9 +357,15 @@ public class WebController extends AbstractController {
     return ResponseEntity.status(e.statusCode).body(rv);
   }
 
-  @RequestMapping(value = {"/search"}, method = RequestMethod.GET)
-  public String search(SearchRequest searchRequest, Model model, Pageable pageRequest, @RequestParam(required = false,
-    defaultValue = "grid") String style, BindingResult results) {
+  @RequestMapping(
+      value = {"/search"},
+      method = RequestMethod.GET)
+  public String search(
+      SearchRequest searchRequest,
+      Model model,
+      Pageable pageRequest,
+      @RequestParam(required = false, defaultValue = "grid") String style,
+      BindingResult results) {
     verifyBinding(results);
 
     model.addAttribute("authentication", authentication);
@@ -368,7 +404,9 @@ public class WebController extends AbstractController {
     return "search-advanced";
   }
 
-  @RequestMapping(value = {"/login"}, method = RequestMethod.GET)
+  @RequestMapping(
+      value = {"/login"},
+      method = RequestMethod.GET)
   public String login() {
     return "login";
   }

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/frontend/model/PageWrapper.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/frontend/model/PageWrapper.java
@@ -5,13 +5,15 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 
 /**
- * "Spring Data Page interface has many nice functions to get current page number, get total pages, etc. But it’s still
- * lack of ways to let me only display partial page range of total pagination. So I created an adapter class to wrap
- * Spring Data Page interface with additional features."
+ * "Spring Data Page interface has many nice functions to get current page number, get total pages,
+ * etc. But it’s still lack of ways to let me only display partial page range of total pagination.
+ * So I created an adapter class to wrap Spring Data Page interface with additional features."
  *
  * @author ralf
  * @param <T> is the paginated type.
- * @see <a href="https://www.javacodegeeks.com/2013/03/implement-bootstrap-pagination-with-spring-data-and-thymeleaf.html">Java Code Geeks article</a>
+ * @see <a
+ *     href="https://www.javacodegeeks.com/2013/03/implement-bootstrap-pagination-with-spring-data-and-thymeleaf.html">Java
+ *     Code Geeks article</a>
  */
 public class PageWrapper<T> {
 
@@ -97,7 +99,6 @@ public class PageWrapper<T> {
 
   public boolean isHasNextPage() {
     return page.hasNext();
-
   }
 
   public class PageItem {

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/model/AbstractDocument.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/model/AbstractDocument.java
@@ -5,8 +5,7 @@ import org.springframework.data.annotation.Id;
 
 public class AbstractDocument {
 
-  @Id
-  private BigInteger documentId;
+  @Id private BigInteger documentId;
 
   public void setId(BigInteger id) {
     this.documentId = id;

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/model/IiifImageApiVersion.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/model/IiifImageApiVersion.java
@@ -1,10 +1,9 @@
 package de.digitalcollections.iiif.bookshelf.model;
 
-/**
- * TODO move to Image API library (model api)
- */
+/** TODO move to Image API library (model api) */
 public enum IiifImageApiVersion {
-  V1_1, V2;
+  V1_1,
+  V2;
 
   public static IiifImageApiVersion getVersion(String context) {
     if (context == null) {

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/model/IiifManifestSummary.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/model/IiifManifestSummary.java
@@ -15,20 +15,19 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.TextScore;
 
 @Document(collection = "iiif-manifest-summaries")
-// @CompoundIndex(name = "labels_descriptions_attributions_idx", def = "{'descriptions.values' : 1, 'labels.values' : 2,
+// @CompoundIndex(name = "labels_descriptions_attributions_idx", def = "{'descriptions.values' : 1,
+// 'labels.values' : 2,
 // 'attributions.values' : 1}")
 public class IiifManifestSummary {
 
-  @TextIndexed
-  private HashMap<Locale, String> attributions = new HashMap<>();
+  @TextIndexed private HashMap<Locale, String> attributions = new HashMap<>();
 
-  @TextIndexed
-  private HashMap<Locale, String> descriptions = new HashMap<>();
+  @TextIndexed private HashMap<Locale, String> descriptions = new HashMap<>();
 
   @TextIndexed(weight = 2)
   private HashMap<Locale, String> labels = new HashMap<>();
 
-// DOES NOT WORK BECAUSE OF CUSTOM @Id (not being mongo object id):
+  // DOES NOT WORK BECAUSE OF CUSTOM @Id (not being mongo object id):
   // @Temporal(TemporalType.TIMESTAMP)
   // @CreatedDate
   // private Date created;
@@ -39,16 +38,13 @@ public class IiifManifestSummary {
 
   private String logoUrl;
 
-  @TextIndexed
-  private String manifestUri;
+  @TextIndexed private String manifestUri;
 
-  @TextScore
-  private Float score;
+  @TextScore private Float score;
 
   private Thumbnail thumbnail;
 
-  @Id
-  private UUID uuid = UUID.randomUUID();
+  @Id private UUID uuid = UUID.randomUUID();
 
   @Indexed(sparse = true, unique = true)
   private String viewId;

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/model/SearchRequest.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/model/SearchRequest.java
@@ -4,8 +4,7 @@ public class SearchRequest {
 
   private String query;
 
-  public SearchRequest() {
-  }
+  public SearchRequest() {}
 
   public SearchRequest(String query) {
     this.query = query;

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/model/Thumbnail.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/model/Thumbnail.java
@@ -6,9 +6,7 @@ public class Thumbnail {
   private String iiifImageServiceUri;
   private String url;
 
-  public Thumbnail() {
-
-  }
+  public Thumbnail() {}
 
   public Thumbnail(IiifImageApiVersion iiifImageApiVersion, String iiifImageServiceUri) {
     setIiifImageApiVersion(iiifImageApiVersion);
@@ -39,20 +37,21 @@ public class Thumbnail {
     if (iiifImageServiceUri != null) {
       iiifImageServiceUri = iiifImageServiceUri.trim();
       if (iiifImageServiceUri.endsWith("/")) {
-        iiifImageServiceUri = iiifImageServiceUri.substring(0, iiifImageServiceUri.lastIndexOf("/"));
+        iiifImageServiceUri =
+            iiifImageServiceUri.substring(0, iiifImageServiceUri.lastIndexOf("/"));
       }
     }
     this.iiifImageServiceUri = iiifImageServiceUri;
   }
 
   public String getUrl() {
-//    if (iiifImageServiceUri != null && iiifImageApiVersion != null) {
-//      if (IiifImageApiVersion.V1_1 == iiifImageApiVersion) {
-//        setUrl(iiifImageServiceUri + "/full/,90/0/native.jpg");
-//      } else if (IiifImageApiVersion.V2 == iiifImageApiVersion) {
-//        setUrl(iiifImageServiceUri + "/full/,90/0/default.jpg");
-//      }
-//    }
+    //    if (iiifImageServiceUri != null && iiifImageApiVersion != null) {
+    //      if (IiifImageApiVersion.V1_1 == iiifImageApiVersion) {
+    //        setUrl(iiifImageServiceUri + "/full/,90/0/native.jpg");
+    //      } else if (IiifImageApiVersion.V2 == iiifImageApiVersion) {
+    //        setUrl(iiifImageServiceUri + "/full/,90/0/default.jpg");
+    //      }
+    //    }
     return url;
   }
 

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/model/exceptions/NotFoundException.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/model/exceptions/NotFoundException.java
@@ -4,5 +4,4 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(HttpStatus.NOT_FOUND)
-public class NotFoundException extends RuntimeException {
-}
+public class NotFoundException extends RuntimeException {}

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/model/exceptions/SearchSyntaxException.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/model/exceptions/SearchSyntaxException.java
@@ -1,5 +1,3 @@
 package de.digitalcollections.iiif.bookshelf.model.exceptions;
 
-public class SearchSyntaxException extends Exception {
-
-}
+public class SearchSyntaxException extends Exception {}

--- a/src/main/java/de/digitalcollections/iiif/bookshelf/util/PreviewImageUtil.java
+++ b/src/main/java/de/digitalcollections/iiif/bookshelf/util/PreviewImageUtil.java
@@ -19,7 +19,6 @@ public class PreviewImageUtil {
     this.manifest = manifest;
   }
 
-
   public static ImageService findImageService(List<Service> services) {
     if (services == null) {
       return null;
@@ -105,6 +104,4 @@ public class PreviewImageUtil {
     }
     return null;
   }
-
-
 }

--- a/src/test/java/de/digitalcollections/iiif/bookshelf/ApplicationTest.java
+++ b/src/test/java/de/digitalcollections/iiif/bookshelf/ApplicationTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.iiif.bookshelf;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import de.digitalcollections.iiif.bookshelf.config.SpringConfigSecurityMonitoring;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -15,28 +17,20 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-/**
- * Basic integration tests for webapp endpoints.
- */
+/** Basic integration tests for webapp endpoints. */
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = {
-  Application.class, SpringConfigSecurityMonitoring.class
-}, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
-) // set random webapp/server port
+@SpringBootTest(
+    classes = {Application.class, SpringConfigSecurityMonitoring.class},
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT) // set random webapp/server port
 @TestPropertySource(properties = {"management.server.port=0"}) // set random management port
 // FIXME: make tests with mocked mongo and solr (or embedded)
 public class ApplicationTest {
 
-  @LocalServerPort
-  private int port;
+  @LocalServerPort private int port;
 
-  @LocalManagementPort
-  private int monitoringPort;
+  @LocalManagementPort private int monitoringPort;
 
-  @Autowired
-  private TestRestTemplate testRestTemplate;
+  @Autowired private TestRestTemplate testRestTemplate;
 
   @Value("${spring.security.user.name}")
   private String monitoringUsername;
@@ -47,40 +41,41 @@ public class ApplicationTest {
   @Test
   public void shouldReturn200WhenSendingRequestToRoot() throws Exception {
     @SuppressWarnings("rawtypes")
-    ResponseEntity<String> entity = this.testRestTemplate.getForEntity(
-      "http://localhost:" + this.port + "/", String.class
-    );
+    ResponseEntity<String> entity =
+        this.testRestTemplate.getForEntity("http://localhost:" + this.port + "/", String.class);
 
     assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
 
   @Test
   public void shouldReturn200WhenSendingRequestToManagementEndpoint() throws Exception {
-    ResponseEntity<Map> entity = this.testRestTemplate.getForEntity(
-      "http://localhost:" + this.monitoringPort + "/monitoring/health", Map.class
-    );
+    ResponseEntity<Map> entity =
+        this.testRestTemplate.getForEntity(
+            "http://localhost:" + this.monitoringPort + "/monitoring/health", Map.class);
 
     assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
 
   @Test
-  public void shouldReturn200WhenSendingAuthorizedRequestToSensitiveManagementEndpoint() throws Exception {
+  public void shouldReturn200WhenSendingAuthorizedRequestToSensitiveManagementEndpoint()
+      throws Exception {
     @SuppressWarnings("rawtypes")
-    ResponseEntity<Map> entity = this.testRestTemplate.withBasicAuth(monitoringUsername, monitoringPassword).getForEntity(
-      "http://localhost:" + this.monitoringPort + "/monitoring/env", Map.class
-    );
+    ResponseEntity<Map> entity =
+        this.testRestTemplate
+            .withBasicAuth(monitoringUsername, monitoringPassword)
+            .getForEntity("http://localhost:" + this.monitoringPort + "/monitoring/env", Map.class);
 
     assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
 
   @Test
-  public void shouldReturn401WhenSendingUnauthorizedRequestToSensitiveManagementEndpoint() throws Exception {
+  public void shouldReturn401WhenSendingUnauthorizedRequestToSensitiveManagementEndpoint()
+      throws Exception {
     @SuppressWarnings("rawtypes")
-    ResponseEntity<Map> entity = this.testRestTemplate.getForEntity(
-      "http://localhost:" + this.monitoringPort + "/monitoring/env", Map.class
-    );
+    ResponseEntity<Map> entity =
+        this.testRestTemplate.getForEntity(
+            "http://localhost:" + this.monitoringPort + "/monitoring/env", Map.class);
 
     assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
   }
-
 }

--- a/src/test/java/de/digitalcollections/iiif/bookshelf/backend/impl/repository/IiiifManifestSummarySearchRepositoryImplSolrjTest.java
+++ b/src/test/java/de/digitalcollections/iiif/bookshelf/backend/impl/repository/IiiifManifestSummarySearchRepositoryImplSolrjTest.java
@@ -1,8 +1,8 @@
 package de.digitalcollections.iiif.bookshelf.backend.impl.repository;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 public class IiiifManifestSummarySearchRepositoryImplSolrjTest {
 

--- a/src/test/java/de/digitalcollections/iiif/bookshelf/business/impl/service/GraciousManifestParserTest.java
+++ b/src/test/java/de/digitalcollections/iiif/bookshelf/business/impl/service/GraciousManifestParserTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.iiif.bookshelf.business.impl.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import de.digitalcollections.iiif.bookshelf.model.IiifManifestSummary;
 import de.digitalcollections.iiif.bookshelf.model.Thumbnail;
 import de.digitalcollections.iiif.model.jackson.IiifObjectMapper;
@@ -13,19 +15,19 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ContextConfiguration(classes = {IiifObjectMapper.class, GraciousManifestParser.class})
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(properties = {"custom.summary.thumbnail.width=280"})
 public class GraciousManifestParserTest {
 
-  @Autowired
-  private GraciousManifestParser parser;
+  @Autowired private GraciousManifestParser parser;
 
   @Test
   public void testGetThumbnail() throws IOException, URISyntaxException {
-    InputStream is = this.getClass().getClassLoader().getResourceAsStream("manifests/manifests.ydc2.yale.edu-manifest-BlakeCopyL.json");
+    InputStream is =
+        this.getClass()
+            .getClassLoader()
+            .getResourceAsStream("manifests/manifests.ydc2.yale.edu-manifest-BlakeCopyL.json");
     IiifManifestSummary iiifManifestSummary = new IiifManifestSummary();
     parser.fillFromInputStream(is, iiifManifestSummary);
     Thumbnail result = iiifManifestSummary.getThumbnail();
@@ -36,7 +38,10 @@ public class GraciousManifestParserTest {
     assertThat(url).isEqualTo(expResult);
 
     // v1 info.json
-    is = this.getClass().getClassLoader().getResourceAsStream("manifests/manifests.ydc2.yale.edu-manifest-Admont23.json");
+    is =
+        this.getClass()
+            .getClassLoader()
+            .getResourceAsStream("manifests/manifests.ydc2.yale.edu-manifest-Admont23.json");
     iiifManifestSummary = new IiifManifestSummary();
     parser.fillFromInputStream(is, iiifManifestSummary);
     result = iiifManifestSummary.getThumbnail();
@@ -47,7 +52,11 @@ public class GraciousManifestParserTest {
     assertThat(url).isEqualTo(expResult);
 
     // v2 info.json
-    is = this.getClass().getClassLoader().getResourceAsStream("manifests/api.digitale-sammlungen.de_iiif_presentation_v2_bsb10916320_00001_u001-manifest.json");
+    is =
+        this.getClass()
+            .getClassLoader()
+            .getResourceAsStream(
+                "manifests/api.digitale-sammlungen.de_iiif_presentation_v2_bsb10916320_00001_u001-manifest.json");
     iiifManifestSummary = new IiifManifestSummary();
     parser.fillFromInputStream(is, iiifManifestSummary);
     result = iiifManifestSummary.getThumbnail();
@@ -58,18 +67,25 @@ public class GraciousManifestParserTest {
     assertThat(url).isEqualTo(expResult);
 
     // info.json inline in manifest:
-    is = this.getClass().getClassLoader().getResourceAsStream("manifests/wellcomelibrary.org_iiif_b19792827-manifest.json");
+    is =
+        this.getClass()
+            .getClassLoader()
+            .getResourceAsStream("manifests/wellcomelibrary.org_iiif_b19792827-manifest.json");
     iiifManifestSummary = new IiifManifestSummary();
     parser.fillFromInputStream(is, iiifManifestSummary);
     result = iiifManifestSummary.getThumbnail();
     assertThat(result).isNotNull();
 
-    expResult = "https://dlcs.io/thumbs/wellcome/1/1a1fcf18-8965-4f72-9324-45c3f6b4b469/full/654,/0/default.jpg";
+    expResult =
+        "https://dlcs.io/thumbs/wellcome/1/1a1fcf18-8965-4f72-9324-45c3f6b4b469/full/654,/0/default.jpg";
     url = result.getUrl();
     assertThat(url).isEqualTo(expResult);
 
     // @value metadata without @language in manifest:
-    is = this.getClass().getClassLoader().getResourceAsStream("manifests/gallica.bnf.fr-manifest-btv1b7100627v.json");
+    is =
+        this.getClass()
+            .getClassLoader()
+            .getResourceAsStream("manifests/gallica.bnf.fr-manifest-btv1b7100627v.json");
     iiifManifestSummary = new IiifManifestSummary();
     parser.fillFromInputStream(is, iiifManifestSummary);
     result = iiifManifestSummary.getThumbnail();

--- a/src/test/java/de/digitalcollections/iiif/bookshelf/business/impl/service/StrictManifestParserTest.java
+++ b/src/test/java/de/digitalcollections/iiif/bookshelf/business/impl/service/StrictManifestParserTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.iiif.bookshelf.business.impl.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.io.Resources;
 import de.digitalcollections.iiif.bookshelf.model.Thumbnail;
 import de.digitalcollections.iiif.model.jackson.IiifObjectMapper;
@@ -12,54 +14,56 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ContextConfiguration(classes = {IiifObjectMapper.class, StrictManifestParser.class})
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(properties = {"custom.summary.thumbnail.width=280"})
 public class StrictManifestParserTest {
 
-  @Autowired
-  private StrictManifestParser parser;
+  @Autowired private StrictManifestParser parser;
 
-  @Autowired
-  private IiifObjectMapper mapper;
+  @Autowired private IiifObjectMapper mapper;
 
   private <T> T readFromResources(String filename, Class<T> clz) throws IOException {
-    return mapper.readValue(
-            Resources.getResource(filename), clz);
+    return mapper.readValue(Resources.getResource(filename), clz);
   }
 
   @Test
   public void testGetThumbnail() throws IOException {
     // v1 info.json
-    Manifest manifest = readFromResources("manifests/manifests.ydc2.yale.edu-manifest-Admont23.json", Manifest.class);
+    Manifest manifest =
+        readFromResources(
+            "manifests/manifests.ydc2.yale.edu-manifest-Admont23.json", Manifest.class);
     String expResult = "classpath:manifests/admont23/full/753,/0/native.jpg";
     Thumbnail result = parser.getThumbnail(manifest);
     String url = result.getUrl();
     assertThat(url).isEqualTo(expResult);
 
     // v2 info.json
-    manifest = readFromResources("manifests/api.digitale-sammlungen.de_iiif_presentation_v2_bsb10916320_00001_u001-manifest.json", Manifest.class);
+    manifest =
+        readFromResources(
+            "manifests/api.digitale-sammlungen.de_iiif_presentation_v2_bsb10916320_00001_u001-manifest.json",
+            Manifest.class);
     expResult = "classpath:manifests/bsb10916320_00001/full/1028,/0/default.jpg";
     result = parser.getThumbnail(manifest);
     url = result.getUrl();
     assertThat(url).isEqualTo(expResult);
 
     // info.json inline in manifest:
-    manifest = readFromResources("manifests/wellcomelibrary.org_iiif_b19792827-manifest.json", Manifest.class);
-    expResult = "https://dlcs.io/thumbs/wellcome/1/1a1fcf18-8965-4f72-9324-45c3f6b4b469/full/654,/0/default.jpg";
+    manifest =
+        readFromResources(
+            "manifests/wellcomelibrary.org_iiif_b19792827-manifest.json", Manifest.class);
+    expResult =
+        "https://dlcs.io/thumbs/wellcome/1/1a1fcf18-8965-4f72-9324-45c3f6b4b469/full/654,/0/default.jpg";
     result = parser.getThumbnail(manifest);
     url = result.getUrl();
     assertThat(url).isEqualTo(expResult);
 
     // @value metadata without @language in manifest:
-    manifest = readFromResources("manifests/gallica.bnf.fr-manifest-btv1b7100627v.json", Manifest.class);
+    manifest =
+        readFromResources("manifests/gallica.bnf.fr-manifest-btv1b7100627v.json", Manifest.class);
     expResult = "http://gallica.bnf.fr/ark:/12148/btv1b7100627v.thumbnail";
     result = parser.getThumbnail(manifest);
     url = result.getUrl();
     assertThat(url).isEqualTo(expResult);
-
   }
-
 }

--- a/src/test/java/de/digitalcollections/iiif/bookshelf/model/ThumbnailTest.java
+++ b/src/test/java/de/digitalcollections/iiif/bookshelf/model/ThumbnailTest.java
@@ -1,8 +1,8 @@
 package de.digitalcollections.iiif.bookshelf.model;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 public class ThumbnailTest {
 
@@ -12,5 +12,4 @@ public class ThumbnailTest {
     Thumbnail thumbnail = new Thumbnail(url);
     assertThat(thumbnail.getUrl()).isEqualTo(url);
   }
-
 }


### PR DESCRIPTION
This PR replaces checkstyle with a maven-plugin that automatically reformats the code to conform with the Google Java Style Guide during the format execution goal, which is executed during the standard clean install and clean test targets.