### PR TITLE
Upgrade dc commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,10 +62,10 @@
   </scm>
 
   <properties>
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <timestamp>${maven.build.timestamp}</timestamp>

--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,8 @@
     <timestamp>${maven.build.timestamp}</timestamp>
     <versionName>${project.version} manually built by ${user.name} at ${maven.build.timestamp}</versionName>
 
-    <version.dc-commons-springboot>4.0.3</version.dc-commons-springboot>
-    <version.dc-commons-springmvc>4.1.1</version.dc-commons-springmvc>
+    <version.dc-commons-springboot>4.1.1</version.dc-commons-springboot>
+    <version.dc-commons-springmvc>4.1.2</version.dc-commons-springmvc>
     <version.iiif-apis>0.3.7</version.iiif-apis>
     <version.json-simple>1.1.1</version.json-simple>
     <version.logstash-logback-encoder>6.3</version.logstash-logback-encoder>

--- a/src/test/java/de/digitalcollections/iiif/bookshelf/business/impl/service/GraciousManifestParserTest.java
+++ b/src/test/java/de/digitalcollections/iiif/bookshelf/business/impl/service/GraciousManifestParserTest.java
@@ -76,8 +76,7 @@ public class GraciousManifestParserTest {
     result = iiifManifestSummary.getThumbnail();
     assertThat(result).isNotNull();
 
-    expResult =
-        "https://dlcs.io/thumbs/wellcome/1/1a1fcf18-8965-4f72-9324-45c3f6b4b469/full/654,/0/default.jpg";
+    expResult = "https://dlcs.io/thumbs/wellcome/5/b19792827_0001.jp2/full/654,/0/default.jpg";
     url = result.getUrl();
     assertThat(url).isEqualTo(expResult);
 

--- a/src/test/java/de/digitalcollections/iiif/bookshelf/business/impl/service/StrictManifestParserTest.java
+++ b/src/test/java/de/digitalcollections/iiif/bookshelf/business/impl/service/StrictManifestParserTest.java
@@ -52,8 +52,7 @@ public class StrictManifestParserTest {
     manifest =
         readFromResources(
             "manifests/wellcomelibrary.org_iiif_b19792827-manifest.json", Manifest.class);
-    expResult =
-        "https://dlcs.io/thumbs/wellcome/1/1a1fcf18-8965-4f72-9324-45c3f6b4b469/full/654,/0/default.jpg";
+    expResult = "https://dlcs.io/thumbs/wellcome/5/b19792827_0001.jp2/full/654,/0/default.jpg";
     result = parser.getThumbnail(manifest);
     url = result.getUrl();
     assertThat(url).isEqualTo(expResult);

--- a/src/test/resources/manifests/wellcomelibrary.org_iiif_b19792827-manifest.json
+++ b/src/test/resources/manifests/wellcomelibrary.org_iiif_b19792827-manifest.json
@@ -18,7 +18,7 @@
     },
     {
       "label": "Attribution",
-      "value": "Wellcome Library<br/>License: CC-BY-NC"
+      "value": "Wellcome Collection<br/>License: CC-BY-NC"
     },
     {
       "label": "",
@@ -101,11 +101,11 @@
           "@type": "sc:Canvas",
           "label": " - ",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/1a1fcf18-8965-4f72-9324-45c3f6b4b469/full/64,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0001.jp2/full/64,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/1a1fcf18-8965-4f72-9324-45c3f6b4b469",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0001.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 654,
@@ -142,18 +142,18 @@
           "width": 1841,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/1a1fcf18-8965-4f72-9324-45c3f6b4b469",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0001.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/1a1fcf18-8965-4f72-9324-45c3f6b4b469/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0001.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 654,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/1a1fcf18-8965-4f72-9324-45c3f6b4b469",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0001.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -173,11 +173,11 @@
           "@type": "sc:Canvas",
           "label": " - ",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/9f4f75dc-2480-4f38-8b67-c762847a3a9f/full/65,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0002.jp2/full/65,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/9f4f75dc-2480-4f38-8b67-c762847a3a9f",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0002.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 664,
@@ -214,18 +214,18 @@
           "width": 1844,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/9f4f75dc-2480-4f38-8b67-c762847a3a9f",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0002.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/9f4f75dc-2480-4f38-8b67-c762847a3a9f/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0002.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 664,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9f4f75dc-2480-4f38-8b67-c762847a3a9f",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0002.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -245,11 +245,11 @@
           "@type": "sc:Canvas",
           "label": "1",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/2b4c38db-9f7d-4772-8e6c-c2a9a7e2c65f/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0003.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/2b4c38db-9f7d-4772-8e6c-c2a9a7e2c65f",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0003.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -286,18 +286,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/2b4c38db-9f7d-4772-8e6c-c2a9a7e2c65f",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0003.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/2b4c38db-9f7d-4772-8e6c-c2a9a7e2c65f/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0003.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/2b4c38db-9f7d-4772-8e6c-c2a9a7e2c65f",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0003.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -317,11 +317,11 @@
           "@type": "sc:Canvas",
           "label": "2",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/b18170e4-cec9-493c-8fbc-5cb1ff841100/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0004.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/b18170e4-cec9-493c-8fbc-5cb1ff841100",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0004.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -358,18 +358,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b18170e4-cec9-493c-8fbc-5cb1ff841100",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0004.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/b18170e4-cec9-493c-8fbc-5cb1ff841100/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0004.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/b18170e4-cec9-493c-8fbc-5cb1ff841100",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0004.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -389,11 +389,11 @@
           "@type": "sc:Canvas",
           "label": "3",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/a9b7cf22-7efb-4cdd-9a9b-5b5f29a2799d/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0005.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/a9b7cf22-7efb-4cdd-9a9b-5b5f29a2799d",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0005.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -430,18 +430,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/a9b7cf22-7efb-4cdd-9a9b-5b5f29a2799d",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0005.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/a9b7cf22-7efb-4cdd-9a9b-5b5f29a2799d/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0005.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a9b7cf22-7efb-4cdd-9a9b-5b5f29a2799d",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0005.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -461,11 +461,11 @@
           "@type": "sc:Canvas",
           "label": "4",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/d4883873-7e4f-4a0d-a1ad-c16477f0fd3e/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0006.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/d4883873-7e4f-4a0d-a1ad-c16477f0fd3e",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0006.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -502,18 +502,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/d4883873-7e4f-4a0d-a1ad-c16477f0fd3e",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0006.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/d4883873-7e4f-4a0d-a1ad-c16477f0fd3e/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0006.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d4883873-7e4f-4a0d-a1ad-c16477f0fd3e",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0006.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -533,11 +533,11 @@
           "@type": "sc:Canvas",
           "label": "5",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/1732d1a0-ec84-4606-8abe-3c0e9196177c/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0007.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/1732d1a0-ec84-4606-8abe-3c0e9196177c",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0007.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -574,18 +574,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/1732d1a0-ec84-4606-8abe-3c0e9196177c",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0007.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/1732d1a0-ec84-4606-8abe-3c0e9196177c/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0007.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/1732d1a0-ec84-4606-8abe-3c0e9196177c",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0007.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -605,11 +605,11 @@
           "@type": "sc:Canvas",
           "label": "6",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/d0396c40-61a4-4a62-bbb4-c8a8f4ae8037/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0008.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/d0396c40-61a4-4a62-bbb4-c8a8f4ae8037",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0008.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -646,18 +646,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/d0396c40-61a4-4a62-bbb4-c8a8f4ae8037",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0008.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/d0396c40-61a4-4a62-bbb4-c8a8f4ae8037/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0008.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d0396c40-61a4-4a62-bbb4-c8a8f4ae8037",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0008.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -677,11 +677,11 @@
           "@type": "sc:Canvas",
           "label": "7",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/799bdc71-aa00-47da-a9af-51054b6c035d/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0009.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/799bdc71-aa00-47da-a9af-51054b6c035d",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0009.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -718,18 +718,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/799bdc71-aa00-47da-a9af-51054b6c035d",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0009.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/799bdc71-aa00-47da-a9af-51054b6c035d/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0009.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/799bdc71-aa00-47da-a9af-51054b6c035d",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0009.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -749,11 +749,11 @@
           "@type": "sc:Canvas",
           "label": "8",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/11a7ed41-7017-4c9e-8c20-ffe6d29957cd/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0010.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/11a7ed41-7017-4c9e-8c20-ffe6d29957cd",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0010.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -790,18 +790,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/11a7ed41-7017-4c9e-8c20-ffe6d29957cd",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0010.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/11a7ed41-7017-4c9e-8c20-ffe6d29957cd/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0010.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/11a7ed41-7017-4c9e-8c20-ffe6d29957cd",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0010.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -821,11 +821,11 @@
           "@type": "sc:Canvas",
           "label": "9",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/a8ec4909-7963-4e9f-94b3-6f83ba8f4322/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0011.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/a8ec4909-7963-4e9f-94b3-6f83ba8f4322",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0011.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -862,18 +862,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/a8ec4909-7963-4e9f-94b3-6f83ba8f4322",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0011.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/a8ec4909-7963-4e9f-94b3-6f83ba8f4322/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0011.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a8ec4909-7963-4e9f-94b3-6f83ba8f4322",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0011.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -893,11 +893,11 @@
           "@type": "sc:Canvas",
           "label": "10",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/0d3da0c3-e348-4b69-8f70-a5a1482e85d3/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0012.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/0d3da0c3-e348-4b69-8f70-a5a1482e85d3",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0012.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -934,18 +934,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/0d3da0c3-e348-4b69-8f70-a5a1482e85d3",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0012.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/0d3da0c3-e348-4b69-8f70-a5a1482e85d3/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0012.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0d3da0c3-e348-4b69-8f70-a5a1482e85d3",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0012.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -965,11 +965,11 @@
           "@type": "sc:Canvas",
           "label": "11",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/178782c2-5762-4a54-978d-e9d92c71b096/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0013.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/178782c2-5762-4a54-978d-e9d92c71b096",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0013.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -1006,18 +1006,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/178782c2-5762-4a54-978d-e9d92c71b096",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0013.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/178782c2-5762-4a54-978d-e9d92c71b096/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0013.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/178782c2-5762-4a54-978d-e9d92c71b096",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0013.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -1037,11 +1037,11 @@
           "@type": "sc:Canvas",
           "label": "12",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/5c17395d-56bd-4e5d-88f1-af462682b126/full/100,62/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0014.jp2/full/100,62/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/5c17395d-56bd-4e5d-88f1-af462682b126",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0014.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 639,
               "width": 1024,
@@ -1078,18 +1078,18 @@
           "width": 2535,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/5c17395d-56bd-4e5d-88f1-af462682b126",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0014.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/5c17395d-56bd-4e5d-88f1-af462682b126/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0014.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 639,
                 "width": 1024,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5c17395d-56bd-4e5d-88f1-af462682b126",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0014.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -1109,11 +1109,11 @@
           "@type": "sc:Canvas",
           "label": "13",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/7ec7acd1-51b0-4abc-a374-046f8df9552a/full/100,58/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0015.jp2/full/100,58/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/7ec7acd1-51b0-4abc-a374-046f8df9552a",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0015.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 595,
               "width": 1024,
@@ -1150,18 +1150,18 @@
           "width": 2539,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/7ec7acd1-51b0-4abc-a374-046f8df9552a",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0015.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/7ec7acd1-51b0-4abc-a374-046f8df9552a/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0015.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 595,
                 "width": 1024,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7ec7acd1-51b0-4abc-a374-046f8df9552a",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0015.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -1181,11 +1181,11 @@
           "@type": "sc:Canvas",
           "label": "14",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/a9c2ffda-087a-4a2a-b34f-2714ce3441be/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0016.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/a9c2ffda-087a-4a2a-b34f-2714ce3441be",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0016.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -1222,18 +1222,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/a9c2ffda-087a-4a2a-b34f-2714ce3441be",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0016.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/a9c2ffda-087a-4a2a-b34f-2714ce3441be/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0016.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a9c2ffda-087a-4a2a-b34f-2714ce3441be",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0016.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -1253,11 +1253,11 @@
           "@type": "sc:Canvas",
           "label": "15",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/f22e625e-49f9-4b43-b046-540dc3e48adc/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0017.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/f22e625e-49f9-4b43-b046-540dc3e48adc",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0017.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -1294,18 +1294,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/f22e625e-49f9-4b43-b046-540dc3e48adc",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0017.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/f22e625e-49f9-4b43-b046-540dc3e48adc/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0017.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f22e625e-49f9-4b43-b046-540dc3e48adc",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0017.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -1325,11 +1325,11 @@
           "@type": "sc:Canvas",
           "label": "16",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/b493aa20-cf08-4cb5-a437-324b4220d096/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0018.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/b493aa20-cf08-4cb5-a437-324b4220d096",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0018.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -1366,18 +1366,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b493aa20-cf08-4cb5-a437-324b4220d096",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0018.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/b493aa20-cf08-4cb5-a437-324b4220d096/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0018.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/b493aa20-cf08-4cb5-a437-324b4220d096",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0018.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -1397,11 +1397,11 @@
           "@type": "sc:Canvas",
           "label": "17",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/4d653d78-69af-479f-8759-76968a898fb5/full/100,58/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0019.jp2/full/100,58/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/4d653d78-69af-479f-8759-76968a898fb5",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0019.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 595,
               "width": 1024,
@@ -1438,18 +1438,18 @@
           "width": 2539,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/4d653d78-69af-479f-8759-76968a898fb5",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0019.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/4d653d78-69af-479f-8759-76968a898fb5/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0019.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 595,
                 "width": 1024,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4d653d78-69af-479f-8759-76968a898fb5",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0019.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -1469,11 +1469,11 @@
           "@type": "sc:Canvas",
           "label": "18",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/bd823ccb-179d-4a3e-aafd-a177f119dc35/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0020.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/bd823ccb-179d-4a3e-aafd-a177f119dc35",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0020.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -1510,18 +1510,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/bd823ccb-179d-4a3e-aafd-a177f119dc35",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0020.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/bd823ccb-179d-4a3e-aafd-a177f119dc35/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0020.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/bd823ccb-179d-4a3e-aafd-a177f119dc35",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0020.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -1541,11 +1541,11 @@
           "@type": "sc:Canvas",
           "label": "19",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/4fed86f7-277e-4b93-acbb-47eca0c8161f/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0021.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/4fed86f7-277e-4b93-acbb-47eca0c8161f",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0021.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -1582,18 +1582,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/4fed86f7-277e-4b93-acbb-47eca0c8161f",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0021.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/4fed86f7-277e-4b93-acbb-47eca0c8161f/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0021.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4fed86f7-277e-4b93-acbb-47eca0c8161f",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0021.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -1613,11 +1613,11 @@
           "@type": "sc:Canvas",
           "label": "20",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/067ba732-e438-49ad-821f-5159eef6e3e4/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0022.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/067ba732-e438-49ad-821f-5159eef6e3e4",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0022.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -1654,18 +1654,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/067ba732-e438-49ad-821f-5159eef6e3e4",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0022.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/067ba732-e438-49ad-821f-5159eef6e3e4/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0022.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/067ba732-e438-49ad-821f-5159eef6e3e4",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0022.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -1685,11 +1685,11 @@
           "@type": "sc:Canvas",
           "label": "21",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/24eb1589-99ff-4b40-8a55-5f856d6e4d67/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0023.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/24eb1589-99ff-4b40-8a55-5f856d6e4d67",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0023.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -1726,18 +1726,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/24eb1589-99ff-4b40-8a55-5f856d6e4d67",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0023.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/24eb1589-99ff-4b40-8a55-5f856d6e4d67/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0023.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/24eb1589-99ff-4b40-8a55-5f856d6e4d67",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0023.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -1757,11 +1757,11 @@
           "@type": "sc:Canvas",
           "label": "22",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/b6f7d43c-1a41-4e56-ae1e-78ff1e5bcbd3/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0024.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/b6f7d43c-1a41-4e56-ae1e-78ff1e5bcbd3",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0024.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -1798,18 +1798,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b6f7d43c-1a41-4e56-ae1e-78ff1e5bcbd3",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0024.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/b6f7d43c-1a41-4e56-ae1e-78ff1e5bcbd3/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0024.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/b6f7d43c-1a41-4e56-ae1e-78ff1e5bcbd3",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0024.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -1829,11 +1829,11 @@
           "@type": "sc:Canvas",
           "label": "23",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/50b6e8df-93f2-49e7-b393-d703d193e283/full/100,58/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0025.jp2/full/100,58/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/50b6e8df-93f2-49e7-b393-d703d193e283",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0025.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 595,
               "width": 1024,
@@ -1870,18 +1870,18 @@
           "width": 2539,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/50b6e8df-93f2-49e7-b393-d703d193e283",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0025.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/50b6e8df-93f2-49e7-b393-d703d193e283/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0025.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 595,
                 "width": 1024,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/50b6e8df-93f2-49e7-b393-d703d193e283",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0025.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -1901,11 +1901,11 @@
           "@type": "sc:Canvas",
           "label": "24",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/be45cd07-bc72-4e99-94aa-c32e232afa49/full/100,58/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0026.jp2/full/100,58/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/be45cd07-bc72-4e99-94aa-c32e232afa49",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0026.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 595,
               "width": 1024,
@@ -1942,18 +1942,18 @@
           "width": 2539,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/be45cd07-bc72-4e99-94aa-c32e232afa49",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0026.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/be45cd07-bc72-4e99-94aa-c32e232afa49/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0026.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 595,
                 "width": 1024,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/be45cd07-bc72-4e99-94aa-c32e232afa49",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0026.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -1973,11 +1973,11 @@
           "@type": "sc:Canvas",
           "label": "25",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/3e8a9898-0e0f-46da-91be-62c17fa9f466/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0027.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/3e8a9898-0e0f-46da-91be-62c17fa9f466",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0027.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -2014,18 +2014,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/3e8a9898-0e0f-46da-91be-62c17fa9f466",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0027.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/3e8a9898-0e0f-46da-91be-62c17fa9f466/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0027.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/3e8a9898-0e0f-46da-91be-62c17fa9f466",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0027.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -2045,11 +2045,11 @@
           "@type": "sc:Canvas",
           "label": "26",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/ce4ba683-c88c-49c6-83b4-afe72c37fba2/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0028.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/ce4ba683-c88c-49c6-83b4-afe72c37fba2",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0028.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -2086,18 +2086,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/ce4ba683-c88c-49c6-83b4-afe72c37fba2",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0028.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/ce4ba683-c88c-49c6-83b4-afe72c37fba2/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0028.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ce4ba683-c88c-49c6-83b4-afe72c37fba2",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0028.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -2117,11 +2117,11 @@
           "@type": "sc:Canvas",
           "label": "27",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/71f5adc1-90e3-4801-8247-ae3d46458646/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0029.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/71f5adc1-90e3-4801-8247-ae3d46458646",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0029.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -2158,18 +2158,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/71f5adc1-90e3-4801-8247-ae3d46458646",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0029.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/71f5adc1-90e3-4801-8247-ae3d46458646/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0029.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/71f5adc1-90e3-4801-8247-ae3d46458646",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0029.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -2189,11 +2189,11 @@
           "@type": "sc:Canvas",
           "label": "28",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/b7efc99e-0f79-478c-b733-28d4d14d9770/full/100,58/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0030.jp2/full/100,58/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/b7efc99e-0f79-478c-b733-28d4d14d9770",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0030.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 595,
               "width": 1024,
@@ -2230,18 +2230,18 @@
           "width": 2539,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b7efc99e-0f79-478c-b733-28d4d14d9770",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0030.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/b7efc99e-0f79-478c-b733-28d4d14d9770/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0030.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 595,
                 "width": 1024,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/b7efc99e-0f79-478c-b733-28d4d14d9770",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0030.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -2261,11 +2261,11 @@
           "@type": "sc:Canvas",
           "label": "29",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/02229b0a-2e2a-4171-8fbc-a3d4a0e62e96/full/100,58/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0031.jp2/full/100,58/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/02229b0a-2e2a-4171-8fbc-a3d4a0e62e96",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0031.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 595,
               "width": 1024,
@@ -2302,18 +2302,18 @@
           "width": 2539,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/02229b0a-2e2a-4171-8fbc-a3d4a0e62e96",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0031.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/02229b0a-2e2a-4171-8fbc-a3d4a0e62e96/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0031.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 595,
                 "width": 1024,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/02229b0a-2e2a-4171-8fbc-a3d4a0e62e96",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0031.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -2333,11 +2333,11 @@
           "@type": "sc:Canvas",
           "label": "30",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/36e416c2-2ede-4961-8cdf-984d69a277f7/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0032.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/36e416c2-2ede-4961-8cdf-984d69a277f7",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0032.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -2374,18 +2374,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/36e416c2-2ede-4961-8cdf-984d69a277f7",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0032.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/36e416c2-2ede-4961-8cdf-984d69a277f7/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0032.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/36e416c2-2ede-4961-8cdf-984d69a277f7",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0032.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -2405,11 +2405,11 @@
           "@type": "sc:Canvas",
           "label": "31",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/5e126182-2dd1-4e59-b466-61dae7b1510b/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0033.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/5e126182-2dd1-4e59-b466-61dae7b1510b",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0033.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -2446,18 +2446,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/5e126182-2dd1-4e59-b466-61dae7b1510b",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0033.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/5e126182-2dd1-4e59-b466-61dae7b1510b/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0033.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5e126182-2dd1-4e59-b466-61dae7b1510b",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0033.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -2477,11 +2477,11 @@
           "@type": "sc:Canvas",
           "label": "32",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/554eab44-6c6a-4bf4-9b39-b47d7b0a754b/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0034.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/554eab44-6c6a-4bf4-9b39-b47d7b0a754b",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0034.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -2518,18 +2518,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/554eab44-6c6a-4bf4-9b39-b47d7b0a754b",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0034.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/554eab44-6c6a-4bf4-9b39-b47d7b0a754b/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0034.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/554eab44-6c6a-4bf4-9b39-b47d7b0a754b",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0034.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -2549,11 +2549,11 @@
           "@type": "sc:Canvas",
           "label": "33",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/9dc56cfb-f148-480b-ad85-10c0abd2e9c3/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0035.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/9dc56cfb-f148-480b-ad85-10c0abd2e9c3",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0035.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -2590,18 +2590,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/9dc56cfb-f148-480b-ad85-10c0abd2e9c3",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0035.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/9dc56cfb-f148-480b-ad85-10c0abd2e9c3/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0035.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9dc56cfb-f148-480b-ad85-10c0abd2e9c3",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0035.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -2621,11 +2621,11 @@
           "@type": "sc:Canvas",
           "label": "34",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/89f53bea-55bf-4329-8fac-9a0d5121114d/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0036.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/89f53bea-55bf-4329-8fac-9a0d5121114d",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0036.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -2662,18 +2662,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/89f53bea-55bf-4329-8fac-9a0d5121114d",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0036.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/89f53bea-55bf-4329-8fac-9a0d5121114d/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0036.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/89f53bea-55bf-4329-8fac-9a0d5121114d",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0036.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -2693,11 +2693,11 @@
           "@type": "sc:Canvas",
           "label": "35",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/b3285acb-f9e8-408c-a0cb-10c07d72b740/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0037.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/b3285acb-f9e8-408c-a0cb-10c07d72b740",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0037.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -2734,18 +2734,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b3285acb-f9e8-408c-a0cb-10c07d72b740",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0037.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/b3285acb-f9e8-408c-a0cb-10c07d72b740/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0037.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/b3285acb-f9e8-408c-a0cb-10c07d72b740",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0037.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -2765,11 +2765,11 @@
           "@type": "sc:Canvas",
           "label": "36",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/6dd12adf-b6a4-4e63-8918-1820a29c066c/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0038.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/6dd12adf-b6a4-4e63-8918-1820a29c066c",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0038.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -2806,18 +2806,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/6dd12adf-b6a4-4e63-8918-1820a29c066c",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0038.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/6dd12adf-b6a4-4e63-8918-1820a29c066c/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0038.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/6dd12adf-b6a4-4e63-8918-1820a29c066c",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0038.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -2837,11 +2837,11 @@
           "@type": "sc:Canvas",
           "label": "37",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/3aebb28c-dcfd-4795-941a-66e0f3b94fd3/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0039.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/3aebb28c-dcfd-4795-941a-66e0f3b94fd3",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0039.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -2878,18 +2878,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/3aebb28c-dcfd-4795-941a-66e0f3b94fd3",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0039.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/3aebb28c-dcfd-4795-941a-66e0f3b94fd3/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0039.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/3aebb28c-dcfd-4795-941a-66e0f3b94fd3",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0039.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -2909,11 +2909,11 @@
           "@type": "sc:Canvas",
           "label": "38",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/317575c2-1664-4290-8d7d-addcd859253a/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0040.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/317575c2-1664-4290-8d7d-addcd859253a",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0040.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -2950,18 +2950,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/317575c2-1664-4290-8d7d-addcd859253a",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0040.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/317575c2-1664-4290-8d7d-addcd859253a/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0040.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/317575c2-1664-4290-8d7d-addcd859253a",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0040.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -2981,11 +2981,11 @@
           "@type": "sc:Canvas",
           "label": "39",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/f11713bc-84f1-4c3a-9a1e-931c60698431/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0041.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/f11713bc-84f1-4c3a-9a1e-931c60698431",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0041.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -3022,18 +3022,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/f11713bc-84f1-4c3a-9a1e-931c60698431",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0041.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/f11713bc-84f1-4c3a-9a1e-931c60698431/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0041.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f11713bc-84f1-4c3a-9a1e-931c60698431",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0041.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -3053,11 +3053,11 @@
           "@type": "sc:Canvas",
           "label": "40",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/06953a63-0c75-4751-90c3-5d8e2560dfbe/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0042.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/06953a63-0c75-4751-90c3-5d8e2560dfbe",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0042.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -3094,18 +3094,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/06953a63-0c75-4751-90c3-5d8e2560dfbe",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0042.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/06953a63-0c75-4751-90c3-5d8e2560dfbe/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0042.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/06953a63-0c75-4751-90c3-5d8e2560dfbe",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0042.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -3125,11 +3125,11 @@
           "@type": "sc:Canvas",
           "label": "41",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/b1e2f1d9-90f8-4ced-9b8a-38fa9cafc057/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0043.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/b1e2f1d9-90f8-4ced-9b8a-38fa9cafc057",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0043.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -3166,18 +3166,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b1e2f1d9-90f8-4ced-9b8a-38fa9cafc057",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0043.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/b1e2f1d9-90f8-4ced-9b8a-38fa9cafc057/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0043.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/b1e2f1d9-90f8-4ced-9b8a-38fa9cafc057",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0043.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -3197,11 +3197,11 @@
           "@type": "sc:Canvas",
           "label": "42",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/8f059ef9-cb75-4370-b37b-4a4f2a5d1b8a/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0044.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/8f059ef9-cb75-4370-b37b-4a4f2a5d1b8a",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0044.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -3238,18 +3238,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/8f059ef9-cb75-4370-b37b-4a4f2a5d1b8a",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0044.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/8f059ef9-cb75-4370-b37b-4a4f2a5d1b8a/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0044.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8f059ef9-cb75-4370-b37b-4a4f2a5d1b8a",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0044.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -3269,11 +3269,11 @@
           "@type": "sc:Canvas",
           "label": "43",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/60e22137-c3c2-4fa8-8733-f80a8f24024e/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0045.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/60e22137-c3c2-4fa8-8733-f80a8f24024e",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0045.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -3310,18 +3310,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/60e22137-c3c2-4fa8-8733-f80a8f24024e",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0045.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/60e22137-c3c2-4fa8-8733-f80a8f24024e/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0045.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/60e22137-c3c2-4fa8-8733-f80a8f24024e",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0045.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -3341,11 +3341,11 @@
           "@type": "sc:Canvas",
           "label": "44",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/ef1846a6-ac8b-44da-b031-89b5bfb9e454/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0046.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/ef1846a6-ac8b-44da-b031-89b5bfb9e454",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0046.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -3382,18 +3382,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/ef1846a6-ac8b-44da-b031-89b5bfb9e454",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0046.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/ef1846a6-ac8b-44da-b031-89b5bfb9e454/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0046.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ef1846a6-ac8b-44da-b031-89b5bfb9e454",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0046.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -3413,11 +3413,11 @@
           "@type": "sc:Canvas",
           "label": "45",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/acd6e35b-0685-4716-9bde-ed0e2f8265e1/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0047.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/acd6e35b-0685-4716-9bde-ed0e2f8265e1",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0047.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -3454,18 +3454,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/acd6e35b-0685-4716-9bde-ed0e2f8265e1",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0047.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/acd6e35b-0685-4716-9bde-ed0e2f8265e1/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0047.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/acd6e35b-0685-4716-9bde-ed0e2f8265e1",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0047.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -3485,11 +3485,11 @@
           "@type": "sc:Canvas",
           "label": "46",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/0d87cb80-2cc1-4bb5-86ad-9b263da2c783/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0048.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/0d87cb80-2cc1-4bb5-86ad-9b263da2c783",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0048.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -3526,18 +3526,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/0d87cb80-2cc1-4bb5-86ad-9b263da2c783",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0048.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/0d87cb80-2cc1-4bb5-86ad-9b263da2c783/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0048.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0d87cb80-2cc1-4bb5-86ad-9b263da2c783",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0048.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -3557,11 +3557,11 @@
           "@type": "sc:Canvas",
           "label": "47",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/8e51c4ff-3b4f-4d63-b259-81173ef21486/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0049.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/8e51c4ff-3b4f-4d63-b259-81173ef21486",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0049.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -3598,18 +3598,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/8e51c4ff-3b4f-4d63-b259-81173ef21486",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0049.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/8e51c4ff-3b4f-4d63-b259-81173ef21486/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0049.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8e51c4ff-3b4f-4d63-b259-81173ef21486",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0049.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -3629,11 +3629,11 @@
           "@type": "sc:Canvas",
           "label": "48",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/c896b268-e36b-4375-949b-95b3f2a6d015/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0050.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/c896b268-e36b-4375-949b-95b3f2a6d015",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0050.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -3670,18 +3670,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/c896b268-e36b-4375-949b-95b3f2a6d015",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0050.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/c896b268-e36b-4375-949b-95b3f2a6d015/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0050.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c896b268-e36b-4375-949b-95b3f2a6d015",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0050.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -3701,11 +3701,11 @@
           "@type": "sc:Canvas",
           "label": "49",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/0308c3ce-abf1-4033-a370-8290c7ba2472/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0051.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/0308c3ce-abf1-4033-a370-8290c7ba2472",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0051.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -3742,18 +3742,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/0308c3ce-abf1-4033-a370-8290c7ba2472",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0051.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/0308c3ce-abf1-4033-a370-8290c7ba2472/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0051.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0308c3ce-abf1-4033-a370-8290c7ba2472",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0051.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -3773,11 +3773,11 @@
           "@type": "sc:Canvas",
           "label": "50",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/ad0a6f82-20ff-4339-9df2-72bb00d13759/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0052.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/ad0a6f82-20ff-4339-9df2-72bb00d13759",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0052.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -3814,18 +3814,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/ad0a6f82-20ff-4339-9df2-72bb00d13759",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0052.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/ad0a6f82-20ff-4339-9df2-72bb00d13759/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0052.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ad0a6f82-20ff-4339-9df2-72bb00d13759",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0052.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -3845,11 +3845,11 @@
           "@type": "sc:Canvas",
           "label": "51",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/01c52274-a012-4324-b73a-d4e41590adf1/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0053.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/01c52274-a012-4324-b73a-d4e41590adf1",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0053.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -3886,18 +3886,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/01c52274-a012-4324-b73a-d4e41590adf1",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0053.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/01c52274-a012-4324-b73a-d4e41590adf1/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0053.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/01c52274-a012-4324-b73a-d4e41590adf1",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0053.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -3917,11 +3917,11 @@
           "@type": "sc:Canvas",
           "label": "52",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/5aa96116-8630-4f20-82de-ed155cd7e13d/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0054.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/5aa96116-8630-4f20-82de-ed155cd7e13d",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0054.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -3958,18 +3958,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/5aa96116-8630-4f20-82de-ed155cd7e13d",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0054.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/5aa96116-8630-4f20-82de-ed155cd7e13d/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0054.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5aa96116-8630-4f20-82de-ed155cd7e13d",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0054.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -3989,11 +3989,11 @@
           "@type": "sc:Canvas",
           "label": "53",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/69a89c15-860f-4d0c-8d87-fb65a6b0154a/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0055.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/69a89c15-860f-4d0c-8d87-fb65a6b0154a",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0055.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -4030,18 +4030,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/69a89c15-860f-4d0c-8d87-fb65a6b0154a",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0055.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/69a89c15-860f-4d0c-8d87-fb65a6b0154a/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0055.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/69a89c15-860f-4d0c-8d87-fb65a6b0154a",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0055.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -4061,11 +4061,11 @@
           "@type": "sc:Canvas",
           "label": "54",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/62fecb3c-7e5b-4179-85e3-ed15d10853b0/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0056.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/62fecb3c-7e5b-4179-85e3-ed15d10853b0",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0056.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -4102,18 +4102,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/62fecb3c-7e5b-4179-85e3-ed15d10853b0",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0056.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/62fecb3c-7e5b-4179-85e3-ed15d10853b0/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0056.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/62fecb3c-7e5b-4179-85e3-ed15d10853b0",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0056.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -4133,11 +4133,11 @@
           "@type": "sc:Canvas",
           "label": "55",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/3490ed6e-676e-49a6-9949-045e4225f890/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0057.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/3490ed6e-676e-49a6-9949-045e4225f890",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0057.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -4174,18 +4174,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/3490ed6e-676e-49a6-9949-045e4225f890",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0057.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/3490ed6e-676e-49a6-9949-045e4225f890/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0057.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/3490ed6e-676e-49a6-9949-045e4225f890",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0057.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -4205,11 +4205,11 @@
           "@type": "sc:Canvas",
           "label": "56",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/859988bf-197b-4fa8-a5f5-bd2d4f891493/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0058.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/859988bf-197b-4fa8-a5f5-bd2d4f891493",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0058.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -4246,18 +4246,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/859988bf-197b-4fa8-a5f5-bd2d4f891493",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0058.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/859988bf-197b-4fa8-a5f5-bd2d4f891493/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0058.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/859988bf-197b-4fa8-a5f5-bd2d4f891493",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0058.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -4277,11 +4277,11 @@
           "@type": "sc:Canvas",
           "label": "57",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/0d22609c-e7de-4cec-8221-81f6774b5fd2/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0059.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/0d22609c-e7de-4cec-8221-81f6774b5fd2",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0059.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -4318,18 +4318,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/0d22609c-e7de-4cec-8221-81f6774b5fd2",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0059.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/0d22609c-e7de-4cec-8221-81f6774b5fd2/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0059.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0d22609c-e7de-4cec-8221-81f6774b5fd2",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0059.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -4349,11 +4349,11 @@
           "@type": "sc:Canvas",
           "label": "58",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/08f648f1-50fc-4613-9af6-51f575728826/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0060.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/08f648f1-50fc-4613-9af6-51f575728826",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0060.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -4390,18 +4390,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/08f648f1-50fc-4613-9af6-51f575728826",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0060.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/08f648f1-50fc-4613-9af6-51f575728826/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0060.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/08f648f1-50fc-4613-9af6-51f575728826",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0060.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -4421,11 +4421,11 @@
           "@type": "sc:Canvas",
           "label": "59",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/f6f800d1-e46e-4a02-96e3-2c871c3248bc/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0061.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/f6f800d1-e46e-4a02-96e3-2c871c3248bc",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0061.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -4462,18 +4462,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/f6f800d1-e46e-4a02-96e3-2c871c3248bc",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0061.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/f6f800d1-e46e-4a02-96e3-2c871c3248bc/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0061.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f6f800d1-e46e-4a02-96e3-2c871c3248bc",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0061.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -4493,11 +4493,11 @@
           "@type": "sc:Canvas",
           "label": "60",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/085f930d-22f1-4d38-adc0-a3a63a6aa274/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0062.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/085f930d-22f1-4d38-adc0-a3a63a6aa274",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0062.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -4534,18 +4534,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/085f930d-22f1-4d38-adc0-a3a63a6aa274",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0062.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/085f930d-22f1-4d38-adc0-a3a63a6aa274/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0062.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/085f930d-22f1-4d38-adc0-a3a63a6aa274",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0062.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -4565,11 +4565,11 @@
           "@type": "sc:Canvas",
           "label": "61",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/c177c428-53cb-411b-a4ab-5550bf1adb51/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0063.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/c177c428-53cb-411b-a4ab-5550bf1adb51",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0063.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -4606,18 +4606,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/c177c428-53cb-411b-a4ab-5550bf1adb51",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0063.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/c177c428-53cb-411b-a4ab-5550bf1adb51/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0063.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c177c428-53cb-411b-a4ab-5550bf1adb51",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0063.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -4637,11 +4637,11 @@
           "@type": "sc:Canvas",
           "label": "62",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/bc690e6a-9bee-418d-94d5-556d18675fd0/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0064.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/bc690e6a-9bee-418d-94d5-556d18675fd0",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0064.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -4678,18 +4678,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/bc690e6a-9bee-418d-94d5-556d18675fd0",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0064.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/bc690e6a-9bee-418d-94d5-556d18675fd0/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0064.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/bc690e6a-9bee-418d-94d5-556d18675fd0",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0064.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -4709,11 +4709,11 @@
           "@type": "sc:Canvas",
           "label": "63",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/ab8a5abb-8098-4750-9565-cd730221ba21/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0065.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/ab8a5abb-8098-4750-9565-cd730221ba21",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0065.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -4750,18 +4750,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/ab8a5abb-8098-4750-9565-cd730221ba21",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0065.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/ab8a5abb-8098-4750-9565-cd730221ba21/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0065.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ab8a5abb-8098-4750-9565-cd730221ba21",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0065.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -4781,11 +4781,11 @@
           "@type": "sc:Canvas",
           "label": "64",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/395f105e-8929-4c9f-8e75-fe31b425df30/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0066.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/395f105e-8929-4c9f-8e75-fe31b425df30",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0066.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -4822,18 +4822,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/395f105e-8929-4c9f-8e75-fe31b425df30",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0066.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/395f105e-8929-4c9f-8e75-fe31b425df30/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0066.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/395f105e-8929-4c9f-8e75-fe31b425df30",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0066.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -4853,11 +4853,11 @@
           "@type": "sc:Canvas",
           "label": "65",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/7947b712-0778-4efe-bcb2-b6ae09ff9592/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0067.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/7947b712-0778-4efe-bcb2-b6ae09ff9592",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0067.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -4894,18 +4894,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/7947b712-0778-4efe-bcb2-b6ae09ff9592",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0067.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/7947b712-0778-4efe-bcb2-b6ae09ff9592/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0067.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7947b712-0778-4efe-bcb2-b6ae09ff9592",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0067.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -4925,11 +4925,11 @@
           "@type": "sc:Canvas",
           "label": "66",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/c837d337-ec5f-4100-bc3a-c9d302abf69a/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0068.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/c837d337-ec5f-4100-bc3a-c9d302abf69a",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0068.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -4966,18 +4966,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/c837d337-ec5f-4100-bc3a-c9d302abf69a",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0068.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/c837d337-ec5f-4100-bc3a-c9d302abf69a/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0068.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c837d337-ec5f-4100-bc3a-c9d302abf69a",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0068.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -4997,11 +4997,11 @@
           "@type": "sc:Canvas",
           "label": "67",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/dec18b61-102a-4de1-a654-954506f9088b/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0069.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/dec18b61-102a-4de1-a654-954506f9088b",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0069.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -5038,18 +5038,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/dec18b61-102a-4de1-a654-954506f9088b",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0069.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/dec18b61-102a-4de1-a654-954506f9088b/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0069.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/dec18b61-102a-4de1-a654-954506f9088b",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0069.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -5069,11 +5069,11 @@
           "@type": "sc:Canvas",
           "label": "68",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/8db71b6e-2ce4-4ce0-b2e9-90ddb9fa6a0c/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0070.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/8db71b6e-2ce4-4ce0-b2e9-90ddb9fa6a0c",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0070.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -5110,18 +5110,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/8db71b6e-2ce4-4ce0-b2e9-90ddb9fa6a0c",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0070.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/8db71b6e-2ce4-4ce0-b2e9-90ddb9fa6a0c/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0070.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8db71b6e-2ce4-4ce0-b2e9-90ddb9fa6a0c",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0070.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -5141,11 +5141,11 @@
           "@type": "sc:Canvas",
           "label": "69",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/c1a97f0c-ff1f-4e49-9271-09131b77c66b/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0071.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/c1a97f0c-ff1f-4e49-9271-09131b77c66b",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0071.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -5182,18 +5182,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/c1a97f0c-ff1f-4e49-9271-09131b77c66b",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0071.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/c1a97f0c-ff1f-4e49-9271-09131b77c66b/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0071.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c1a97f0c-ff1f-4e49-9271-09131b77c66b",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0071.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -5213,11 +5213,11 @@
           "@type": "sc:Canvas",
           "label": "70",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/bf882f4a-4a15-41b8-8016-0551ee2edd5c/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0072.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/bf882f4a-4a15-41b8-8016-0551ee2edd5c",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0072.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -5254,18 +5254,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/bf882f4a-4a15-41b8-8016-0551ee2edd5c",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0072.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/bf882f4a-4a15-41b8-8016-0551ee2edd5c/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0072.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/bf882f4a-4a15-41b8-8016-0551ee2edd5c",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0072.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -5285,11 +5285,11 @@
           "@type": "sc:Canvas",
           "label": "71",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/d2e19886-bf5a-40aa-8f00-86d0d40c2850/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0073.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/d2e19886-bf5a-40aa-8f00-86d0d40c2850",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0073.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -5326,18 +5326,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/d2e19886-bf5a-40aa-8f00-86d0d40c2850",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0073.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/d2e19886-bf5a-40aa-8f00-86d0d40c2850/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0073.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d2e19886-bf5a-40aa-8f00-86d0d40c2850",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0073.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -5357,11 +5357,11 @@
           "@type": "sc:Canvas",
           "label": "72",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/7997147c-984a-4f10-aa57-08d28422cd3c/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0074.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/7997147c-984a-4f10-aa57-08d28422cd3c",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0074.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -5398,18 +5398,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/7997147c-984a-4f10-aa57-08d28422cd3c",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0074.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/7997147c-984a-4f10-aa57-08d28422cd3c/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0074.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7997147c-984a-4f10-aa57-08d28422cd3c",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0074.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -5429,11 +5429,11 @@
           "@type": "sc:Canvas",
           "label": "73",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/213e2983-6044-43b2-95b8-26bae8272bb2/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0075.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/213e2983-6044-43b2-95b8-26bae8272bb2",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0075.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -5470,18 +5470,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/213e2983-6044-43b2-95b8-26bae8272bb2",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0075.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/213e2983-6044-43b2-95b8-26bae8272bb2/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0075.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/213e2983-6044-43b2-95b8-26bae8272bb2",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0075.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -5501,11 +5501,11 @@
           "@type": "sc:Canvas",
           "label": "74",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/395fb973-dcc9-4c85-aad5-7b4ebb73c463/full/100,58/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0076.jp2/full/100,58/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/395fb973-dcc9-4c85-aad5-7b4ebb73c463",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0076.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 595,
               "width": 1024,
@@ -5542,18 +5542,18 @@
           "width": 2539,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/395fb973-dcc9-4c85-aad5-7b4ebb73c463",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0076.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/395fb973-dcc9-4c85-aad5-7b4ebb73c463/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0076.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 595,
                 "width": 1024,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/395fb973-dcc9-4c85-aad5-7b4ebb73c463",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0076.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -5573,11 +5573,11 @@
           "@type": "sc:Canvas",
           "label": "75",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/3b9b6f2b-b5eb-48df-a846-1579b1dd8f5a/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0077.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/3b9b6f2b-b5eb-48df-a846-1579b1dd8f5a",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0077.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -5614,18 +5614,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/3b9b6f2b-b5eb-48df-a846-1579b1dd8f5a",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0077.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/3b9b6f2b-b5eb-48df-a846-1579b1dd8f5a/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0077.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/3b9b6f2b-b5eb-48df-a846-1579b1dd8f5a",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0077.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -5645,11 +5645,11 @@
           "@type": "sc:Canvas",
           "label": "76",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/65895606-6a31-45da-8b07-a3d848f83762/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0078.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/65895606-6a31-45da-8b07-a3d848f83762",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0078.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -5686,18 +5686,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/65895606-6a31-45da-8b07-a3d848f83762",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0078.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/65895606-6a31-45da-8b07-a3d848f83762/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0078.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/65895606-6a31-45da-8b07-a3d848f83762",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0078.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -5717,11 +5717,11 @@
           "@type": "sc:Canvas",
           "label": "77",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/f86cf8b7-bc43-47d8-83ac-d2bbe7ed0a56/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0079.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/f86cf8b7-bc43-47d8-83ac-d2bbe7ed0a56",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0079.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -5758,18 +5758,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/f86cf8b7-bc43-47d8-83ac-d2bbe7ed0a56",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0079.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/f86cf8b7-bc43-47d8-83ac-d2bbe7ed0a56/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0079.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f86cf8b7-bc43-47d8-83ac-d2bbe7ed0a56",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0079.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -5789,11 +5789,11 @@
           "@type": "sc:Canvas",
           "label": "78",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/d4929e2c-012f-421f-ad82-f17b02ab87c1/full/100,58/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0080.jp2/full/100,58/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/d4929e2c-012f-421f-ad82-f17b02ab87c1",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0080.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 595,
               "width": 1024,
@@ -5830,18 +5830,18 @@
           "width": 2539,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/d4929e2c-012f-421f-ad82-f17b02ab87c1",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0080.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/d4929e2c-012f-421f-ad82-f17b02ab87c1/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0080.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 595,
                 "width": 1024,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d4929e2c-012f-421f-ad82-f17b02ab87c1",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0080.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -5861,11 +5861,11 @@
           "@type": "sc:Canvas",
           "label": "79",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/2a98fe78-4557-45a1-8f8c-b5f68e6a8c82/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0081.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/2a98fe78-4557-45a1-8f8c-b5f68e6a8c82",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0081.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -5902,18 +5902,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/2a98fe78-4557-45a1-8f8c-b5f68e6a8c82",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0081.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/2a98fe78-4557-45a1-8f8c-b5f68e6a8c82/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0081.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/2a98fe78-4557-45a1-8f8c-b5f68e6a8c82",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0081.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -5933,11 +5933,11 @@
           "@type": "sc:Canvas",
           "label": "80",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/b60a0a81-6ebf-4001-be4b-e12c053dd980/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0082.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/b60a0a81-6ebf-4001-be4b-e12c053dd980",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0082.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -5974,18 +5974,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b60a0a81-6ebf-4001-be4b-e12c053dd980",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0082.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/b60a0a81-6ebf-4001-be4b-e12c053dd980/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0082.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/b60a0a81-6ebf-4001-be4b-e12c053dd980",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0082.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -6005,11 +6005,11 @@
           "@type": "sc:Canvas",
           "label": "81",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/43c735d6-f928-4267-b9b7-b6ffab22eba7/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0083.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/43c735d6-f928-4267-b9b7-b6ffab22eba7",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0083.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -6046,18 +6046,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/43c735d6-f928-4267-b9b7-b6ffab22eba7",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0083.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/43c735d6-f928-4267-b9b7-b6ffab22eba7/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0083.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/43c735d6-f928-4267-b9b7-b6ffab22eba7",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0083.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -6077,11 +6077,11 @@
           "@type": "sc:Canvas",
           "label": "82",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/47647891-b667-422a-9439-974924fb7dea/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0084.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/47647891-b667-422a-9439-974924fb7dea",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0084.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -6118,18 +6118,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/47647891-b667-422a-9439-974924fb7dea",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0084.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/47647891-b667-422a-9439-974924fb7dea/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0084.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/47647891-b667-422a-9439-974924fb7dea",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0084.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -6149,11 +6149,11 @@
           "@type": "sc:Canvas",
           "label": "83",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/c653a419-091f-4610-81c5-eae12c132a06/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0085.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/c653a419-091f-4610-81c5-eae12c132a06",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0085.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -6190,18 +6190,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/c653a419-091f-4610-81c5-eae12c132a06",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0085.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/c653a419-091f-4610-81c5-eae12c132a06/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0085.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c653a419-091f-4610-81c5-eae12c132a06",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0085.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -6221,11 +6221,11 @@
           "@type": "sc:Canvas",
           "label": "84",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/a8addd4e-001b-463e-be4f-734992abc471/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0086.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/a8addd4e-001b-463e-be4f-734992abc471",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0086.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -6262,18 +6262,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/a8addd4e-001b-463e-be4f-734992abc471",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0086.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/a8addd4e-001b-463e-be4f-734992abc471/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0086.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a8addd4e-001b-463e-be4f-734992abc471",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0086.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -6293,11 +6293,11 @@
           "@type": "sc:Canvas",
           "label": "85",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/5fa36f9c-bd2f-47f0-89b9-2ccbb4a89f5f/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0087.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/5fa36f9c-bd2f-47f0-89b9-2ccbb4a89f5f",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0087.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -6334,18 +6334,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/5fa36f9c-bd2f-47f0-89b9-2ccbb4a89f5f",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0087.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/5fa36f9c-bd2f-47f0-89b9-2ccbb4a89f5f/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0087.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5fa36f9c-bd2f-47f0-89b9-2ccbb4a89f5f",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0087.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -6365,11 +6365,11 @@
           "@type": "sc:Canvas",
           "label": "86",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/611753db-5bbc-47e1-8c8a-4d853e45d3a1/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0088.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/611753db-5bbc-47e1-8c8a-4d853e45d3a1",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0088.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -6406,18 +6406,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/611753db-5bbc-47e1-8c8a-4d853e45d3a1",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0088.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/611753db-5bbc-47e1-8c8a-4d853e45d3a1/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0088.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/611753db-5bbc-47e1-8c8a-4d853e45d3a1",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0088.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -6437,11 +6437,11 @@
           "@type": "sc:Canvas",
           "label": "87",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/6c2fc413-c2a7-4ddf-a101-eb9116257809/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0089.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/6c2fc413-c2a7-4ddf-a101-eb9116257809",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0089.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -6478,18 +6478,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/6c2fc413-c2a7-4ddf-a101-eb9116257809",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0089.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/6c2fc413-c2a7-4ddf-a101-eb9116257809/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0089.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/6c2fc413-c2a7-4ddf-a101-eb9116257809",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0089.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -6509,11 +6509,11 @@
           "@type": "sc:Canvas",
           "label": "88",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/fffdf53c-52c4-4dcb-8a26-04d598ed1c57/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0090.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/fffdf53c-52c4-4dcb-8a26-04d598ed1c57",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0090.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -6550,18 +6550,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/fffdf53c-52c4-4dcb-8a26-04d598ed1c57",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0090.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/fffdf53c-52c4-4dcb-8a26-04d598ed1c57/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0090.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/fffdf53c-52c4-4dcb-8a26-04d598ed1c57",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0090.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -6581,11 +6581,11 @@
           "@type": "sc:Canvas",
           "label": "89",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/55ed220b-183b-42a1-816b-62ae7b208797/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0091.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/55ed220b-183b-42a1-816b-62ae7b208797",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0091.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -6622,18 +6622,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/55ed220b-183b-42a1-816b-62ae7b208797",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0091.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/55ed220b-183b-42a1-816b-62ae7b208797/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0091.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/55ed220b-183b-42a1-816b-62ae7b208797",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0091.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -6653,11 +6653,11 @@
           "@type": "sc:Canvas",
           "label": "90",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/a939c74a-d496-4a9b-ae57-e435271f5b8d/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0092.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/a939c74a-d496-4a9b-ae57-e435271f5b8d",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0092.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -6694,18 +6694,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/a939c74a-d496-4a9b-ae57-e435271f5b8d",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0092.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/a939c74a-d496-4a9b-ae57-e435271f5b8d/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0092.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a939c74a-d496-4a9b-ae57-e435271f5b8d",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0092.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -6725,11 +6725,11 @@
           "@type": "sc:Canvas",
           "label": "91",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/bb4bc355-78ce-4aea-99e5-8f1b3865140e/full/100,54/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0093.jp2/full/100,54/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/bb4bc355-78ce-4aea-99e5-8f1b3865140e",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0093.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 552,
               "width": 1024,
@@ -6766,18 +6766,18 @@
           "width": 2734,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/bb4bc355-78ce-4aea-99e5-8f1b3865140e",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0093.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/bb4bc355-78ce-4aea-99e5-8f1b3865140e/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0093.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 552,
                 "width": 1024,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/bb4bc355-78ce-4aea-99e5-8f1b3865140e",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0093.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -6797,11 +6797,11 @@
           "@type": "sc:Canvas",
           "label": "92",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/8bd2993d-6792-497d-b017-c16e6f063088/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0094.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/8bd2993d-6792-497d-b017-c16e6f063088",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0094.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -6838,18 +6838,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/8bd2993d-6792-497d-b017-c16e6f063088",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0094.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/8bd2993d-6792-497d-b017-c16e6f063088/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0094.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8bd2993d-6792-497d-b017-c16e6f063088",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0094.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -6869,11 +6869,11 @@
           "@type": "sc:Canvas",
           "label": "93",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/dabb8529-b44f-43a0-91c5-6e9b5ec8d1e5/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0095.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/dabb8529-b44f-43a0-91c5-6e9b5ec8d1e5",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0095.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -6910,18 +6910,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/dabb8529-b44f-43a0-91c5-6e9b5ec8d1e5",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0095.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/dabb8529-b44f-43a0-91c5-6e9b5ec8d1e5/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0095.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/dabb8529-b44f-43a0-91c5-6e9b5ec8d1e5",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0095.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -6941,11 +6941,11 @@
           "@type": "sc:Canvas",
           "label": "94",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/5220cfdb-fca7-451e-a658-21ff3e323b9f/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0096.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/5220cfdb-fca7-451e-a658-21ff3e323b9f",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0096.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -6982,18 +6982,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/5220cfdb-fca7-451e-a658-21ff3e323b9f",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0096.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/5220cfdb-fca7-451e-a658-21ff3e323b9f/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0096.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5220cfdb-fca7-451e-a658-21ff3e323b9f",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0096.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -7013,11 +7013,11 @@
           "@type": "sc:Canvas",
           "label": "95",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/8a897bfa-b927-48ad-8071-baa544270466/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0097.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/8a897bfa-b927-48ad-8071-baa544270466",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0097.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -7054,18 +7054,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/8a897bfa-b927-48ad-8071-baa544270466",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0097.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/8a897bfa-b927-48ad-8071-baa544270466/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0097.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8a897bfa-b927-48ad-8071-baa544270466",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0097.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -7085,11 +7085,11 @@
           "@type": "sc:Canvas",
           "label": "96",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/0c7ff833-e856-4d54-b7e4-8755b2f578b2/full/100,58/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0098.jp2/full/100,58/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/0c7ff833-e856-4d54-b7e4-8755b2f578b2",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0098.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 595,
               "width": 1024,
@@ -7126,18 +7126,18 @@
           "width": 2539,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/0c7ff833-e856-4d54-b7e4-8755b2f578b2",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0098.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/0c7ff833-e856-4d54-b7e4-8755b2f578b2/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0098.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 595,
                 "width": 1024,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0c7ff833-e856-4d54-b7e4-8755b2f578b2",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0098.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -7157,11 +7157,11 @@
           "@type": "sc:Canvas",
           "label": "97",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/c3f10d73-7f5b-4bf2-a796-721448057945/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0099.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/c3f10d73-7f5b-4bf2-a796-721448057945",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0099.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -7198,18 +7198,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/c3f10d73-7f5b-4bf2-a796-721448057945",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0099.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/c3f10d73-7f5b-4bf2-a796-721448057945/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0099.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c3f10d73-7f5b-4bf2-a796-721448057945",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0099.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -7229,11 +7229,11 @@
           "@type": "sc:Canvas",
           "label": "98",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/dc940566-b800-4a71-a9ef-8e2ba334429a/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0100.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/dc940566-b800-4a71-a9ef-8e2ba334429a",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0100.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -7270,18 +7270,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/dc940566-b800-4a71-a9ef-8e2ba334429a",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0100.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/dc940566-b800-4a71-a9ef-8e2ba334429a/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0100.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/dc940566-b800-4a71-a9ef-8e2ba334429a",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0100.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -7301,11 +7301,11 @@
           "@type": "sc:Canvas",
           "label": "99",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/bc02ff3c-a676-4da2-970b-724780a65f90/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0101.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/bc02ff3c-a676-4da2-970b-724780a65f90",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0101.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -7342,18 +7342,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/bc02ff3c-a676-4da2-970b-724780a65f90",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0101.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/bc02ff3c-a676-4da2-970b-724780a65f90/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0101.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/bc02ff3c-a676-4da2-970b-724780a65f90",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0101.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -7373,11 +7373,11 @@
           "@type": "sc:Canvas",
           "label": "100",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/2cbb9619-1e64-42fe-919b-32e9a48b840c/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0102.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/2cbb9619-1e64-42fe-919b-32e9a48b840c",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0102.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -7414,18 +7414,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/2cbb9619-1e64-42fe-919b-32e9a48b840c",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0102.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/2cbb9619-1e64-42fe-919b-32e9a48b840c/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0102.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/2cbb9619-1e64-42fe-919b-32e9a48b840c",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0102.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -7445,11 +7445,11 @@
           "@type": "sc:Canvas",
           "label": "101",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/0ecd87aa-2197-44bd-b766-8e6d95e44501/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0103.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/0ecd87aa-2197-44bd-b766-8e6d95e44501",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0103.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -7486,18 +7486,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/0ecd87aa-2197-44bd-b766-8e6d95e44501",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0103.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/0ecd87aa-2197-44bd-b766-8e6d95e44501/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0103.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0ecd87aa-2197-44bd-b766-8e6d95e44501",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0103.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -7517,11 +7517,11 @@
           "@type": "sc:Canvas",
           "label": "102",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/309156bb-fed5-4087-bc6d-49d038a27c51/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0104.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/309156bb-fed5-4087-bc6d-49d038a27c51",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0104.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -7558,18 +7558,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/309156bb-fed5-4087-bc6d-49d038a27c51",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0104.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/309156bb-fed5-4087-bc6d-49d038a27c51/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0104.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/309156bb-fed5-4087-bc6d-49d038a27c51",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0104.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -7589,11 +7589,11 @@
           "@type": "sc:Canvas",
           "label": "103",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/047e9d7e-d4f8-4995-9c5e-0a08d91e6442/full/100,64/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0105.jp2/full/100,64/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/047e9d7e-d4f8-4995-9c5e-0a08d91e6442",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0105.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 659,
               "width": 1024,
@@ -7630,18 +7630,18 @@
           "width": 2539,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/047e9d7e-d4f8-4995-9c5e-0a08d91e6442",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0105.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/047e9d7e-d4f8-4995-9c5e-0a08d91e6442/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0105.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 659,
                 "width": 1024,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/047e9d7e-d4f8-4995-9c5e-0a08d91e6442",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0105.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -7661,11 +7661,11 @@
           "@type": "sc:Canvas",
           "label": "104",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/5c0b8307-69bb-48c4-adac-d94835ed845b/full/100,58/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0106.jp2/full/100,58/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/5c0b8307-69bb-48c4-adac-d94835ed845b",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0106.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 595,
               "width": 1024,
@@ -7702,18 +7702,18 @@
           "width": 2539,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/5c0b8307-69bb-48c4-adac-d94835ed845b",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0106.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/5c0b8307-69bb-48c4-adac-d94835ed845b/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0106.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 595,
                 "width": 1024,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5c0b8307-69bb-48c4-adac-d94835ed845b",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0106.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -7733,11 +7733,11 @@
           "@type": "sc:Canvas",
           "label": "105",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/c41ecc41-4c8f-4304-afb9-5e8f902260e8/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0107.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/c41ecc41-4c8f-4304-afb9-5e8f902260e8",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0107.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -7774,18 +7774,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/c41ecc41-4c8f-4304-afb9-5e8f902260e8",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0107.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/c41ecc41-4c8f-4304-afb9-5e8f902260e8/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0107.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c41ecc41-4c8f-4304-afb9-5e8f902260e8",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0107.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -7805,11 +7805,11 @@
           "@type": "sc:Canvas",
           "label": "106",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/67e1f3be-e46a-48f4-be04-4249dfd41ccf/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0108.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/67e1f3be-e46a-48f4-be04-4249dfd41ccf",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0108.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -7846,18 +7846,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/67e1f3be-e46a-48f4-be04-4249dfd41ccf",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0108.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/67e1f3be-e46a-48f4-be04-4249dfd41ccf/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0108.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/67e1f3be-e46a-48f4-be04-4249dfd41ccf",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0108.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -7877,11 +7877,11 @@
           "@type": "sc:Canvas",
           "label": "107",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/ac6dec79-1891-4c00-b72b-27e803b89d12/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0109.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/ac6dec79-1891-4c00-b72b-27e803b89d12",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0109.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -7918,18 +7918,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/ac6dec79-1891-4c00-b72b-27e803b89d12",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0109.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/ac6dec79-1891-4c00-b72b-27e803b89d12/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0109.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/ac6dec79-1891-4c00-b72b-27e803b89d12",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0109.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -7949,11 +7949,11 @@
           "@type": "sc:Canvas",
           "label": "108",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/88cf0cf3-2bca-4b54-bb44-56891cb7eaf0/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0110.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/88cf0cf3-2bca-4b54-bb44-56891cb7eaf0",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0110.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -7990,18 +7990,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/88cf0cf3-2bca-4b54-bb44-56891cb7eaf0",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0110.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/88cf0cf3-2bca-4b54-bb44-56891cb7eaf0/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0110.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/88cf0cf3-2bca-4b54-bb44-56891cb7eaf0",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0110.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -8021,11 +8021,11 @@
           "@type": "sc:Canvas",
           "label": "109",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/a77313ba-e745-4625-b3cc-3aaf737c48b3/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0111.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/a77313ba-e745-4625-b3cc-3aaf737c48b3",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0111.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -8062,18 +8062,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/a77313ba-e745-4625-b3cc-3aaf737c48b3",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0111.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/a77313ba-e745-4625-b3cc-3aaf737c48b3/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0111.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a77313ba-e745-4625-b3cc-3aaf737c48b3",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0111.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -8093,11 +8093,11 @@
           "@type": "sc:Canvas",
           "label": "110",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/18844ea0-578d-4d96-806d-9a700f00c870/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0112.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/18844ea0-578d-4d96-806d-9a700f00c870",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0112.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -8134,18 +8134,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/18844ea0-578d-4d96-806d-9a700f00c870",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0112.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/18844ea0-578d-4d96-806d-9a700f00c870/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0112.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/18844ea0-578d-4d96-806d-9a700f00c870",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0112.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -8165,11 +8165,11 @@
           "@type": "sc:Canvas",
           "label": "111",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/251c9c8f-98cd-4fa9-bc5e-3de482498878/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0113.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/251c9c8f-98cd-4fa9-bc5e-3de482498878",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0113.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -8206,18 +8206,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/251c9c8f-98cd-4fa9-bc5e-3de482498878",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0113.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/251c9c8f-98cd-4fa9-bc5e-3de482498878/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0113.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/251c9c8f-98cd-4fa9-bc5e-3de482498878",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0113.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -8237,11 +8237,11 @@
           "@type": "sc:Canvas",
           "label": "112",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/41ddf258-ef81-4ccc-bafb-57047ca180bf/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0114.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/41ddf258-ef81-4ccc-bafb-57047ca180bf",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0114.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -8278,18 +8278,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/41ddf258-ef81-4ccc-bafb-57047ca180bf",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0114.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/41ddf258-ef81-4ccc-bafb-57047ca180bf/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0114.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/41ddf258-ef81-4ccc-bafb-57047ca180bf",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0114.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -8309,11 +8309,11 @@
           "@type": "sc:Canvas",
           "label": "113",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/96ed8013-81a8-448b-8e1c-77fc94d3def7/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0115.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/96ed8013-81a8-448b-8e1c-77fc94d3def7",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0115.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -8350,18 +8350,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/96ed8013-81a8-448b-8e1c-77fc94d3def7",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0115.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/96ed8013-81a8-448b-8e1c-77fc94d3def7/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0115.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/96ed8013-81a8-448b-8e1c-77fc94d3def7",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0115.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -8381,11 +8381,11 @@
           "@type": "sc:Canvas",
           "label": "114",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/3def1f2f-6e21-4946-99a8-3181dfb951e3/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0116.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/3def1f2f-6e21-4946-99a8-3181dfb951e3",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0116.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -8422,18 +8422,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/3def1f2f-6e21-4946-99a8-3181dfb951e3",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0116.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/3def1f2f-6e21-4946-99a8-3181dfb951e3/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0116.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/3def1f2f-6e21-4946-99a8-3181dfb951e3",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0116.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -8453,11 +8453,11 @@
           "@type": "sc:Canvas",
           "label": "115",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/e8d1ae9e-40ca-42b0-a336-b7c27ae1d701/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0117.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/e8d1ae9e-40ca-42b0-a336-b7c27ae1d701",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0117.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -8494,18 +8494,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/e8d1ae9e-40ca-42b0-a336-b7c27ae1d701",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0117.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/e8d1ae9e-40ca-42b0-a336-b7c27ae1d701/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0117.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/e8d1ae9e-40ca-42b0-a336-b7c27ae1d701",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0117.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -8525,11 +8525,11 @@
           "@type": "sc:Canvas",
           "label": "116",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/2de4aa35-343b-46d3-ad7a-7ea4654ed4d9/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0118.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/2de4aa35-343b-46d3-ad7a-7ea4654ed4d9",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0118.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -8566,18 +8566,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/2de4aa35-343b-46d3-ad7a-7ea4654ed4d9",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0118.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/2de4aa35-343b-46d3-ad7a-7ea4654ed4d9/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0118.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/2de4aa35-343b-46d3-ad7a-7ea4654ed4d9",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0118.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -8597,11 +8597,11 @@
           "@type": "sc:Canvas",
           "label": "117",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/a0d5e2c0-6f97-48a9-b85f-298bf6673a63/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0119.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/a0d5e2c0-6f97-48a9-b85f-298bf6673a63",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0119.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -8638,18 +8638,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/a0d5e2c0-6f97-48a9-b85f-298bf6673a63",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0119.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/a0d5e2c0-6f97-48a9-b85f-298bf6673a63/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0119.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a0d5e2c0-6f97-48a9-b85f-298bf6673a63",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0119.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -8669,11 +8669,11 @@
           "@type": "sc:Canvas",
           "label": "118",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/1bcfa9f7-c3f7-48ea-b5b5-1f569692b8b5/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0120.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/1bcfa9f7-c3f7-48ea-b5b5-1f569692b8b5",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0120.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -8710,18 +8710,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/1bcfa9f7-c3f7-48ea-b5b5-1f569692b8b5",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0120.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/1bcfa9f7-c3f7-48ea-b5b5-1f569692b8b5/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0120.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/1bcfa9f7-c3f7-48ea-b5b5-1f569692b8b5",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0120.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -8741,11 +8741,11 @@
           "@type": "sc:Canvas",
           "label": "119",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/dc43a3d5-a12e-44a7-bb02-236a79b10ae6/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0121.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/dc43a3d5-a12e-44a7-bb02-236a79b10ae6",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0121.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -8782,18 +8782,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/dc43a3d5-a12e-44a7-bb02-236a79b10ae6",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0121.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/dc43a3d5-a12e-44a7-bb02-236a79b10ae6/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0121.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/dc43a3d5-a12e-44a7-bb02-236a79b10ae6",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0121.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -8813,11 +8813,11 @@
           "@type": "sc:Canvas",
           "label": "120",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/63f46bfb-9d96-4295-9913-f8586b720ec4/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0122.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/63f46bfb-9d96-4295-9913-f8586b720ec4",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0122.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -8854,18 +8854,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/63f46bfb-9d96-4295-9913-f8586b720ec4",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0122.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/63f46bfb-9d96-4295-9913-f8586b720ec4/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0122.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/63f46bfb-9d96-4295-9913-f8586b720ec4",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0122.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -8885,11 +8885,11 @@
           "@type": "sc:Canvas",
           "label": "121",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/7a49c161-71b0-444f-8f7c-586981397dd9/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0123.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/7a49c161-71b0-444f-8f7c-586981397dd9",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0123.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -8926,18 +8926,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/7a49c161-71b0-444f-8f7c-586981397dd9",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0123.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/7a49c161-71b0-444f-8f7c-586981397dd9/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0123.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/7a49c161-71b0-444f-8f7c-586981397dd9",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0123.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -8957,11 +8957,11 @@
           "@type": "sc:Canvas",
           "label": "122",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/f9c67bff-1dc8-4abf-88f6-3bd6b98ff6c2/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0124.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/f9c67bff-1dc8-4abf-88f6-3bd6b98ff6c2",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0124.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -8998,18 +8998,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/f9c67bff-1dc8-4abf-88f6-3bd6b98ff6c2",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0124.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/f9c67bff-1dc8-4abf-88f6-3bd6b98ff6c2/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0124.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f9c67bff-1dc8-4abf-88f6-3bd6b98ff6c2",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0124.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -9029,11 +9029,11 @@
           "@type": "sc:Canvas",
           "label": "123",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/b83bd9db-b1a5-4fcd-988d-6600937b7a98/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0125.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/b83bd9db-b1a5-4fcd-988d-6600937b7a98",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0125.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -9070,18 +9070,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b83bd9db-b1a5-4fcd-988d-6600937b7a98",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0125.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/b83bd9db-b1a5-4fcd-988d-6600937b7a98/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0125.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/b83bd9db-b1a5-4fcd-988d-6600937b7a98",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0125.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -9101,11 +9101,11 @@
           "@type": "sc:Canvas",
           "label": "124",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/38bb9fa6-ecb7-4ae3-8427-3f99f9992bc2/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0126.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/38bb9fa6-ecb7-4ae3-8427-3f99f9992bc2",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0126.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -9142,18 +9142,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/38bb9fa6-ecb7-4ae3-8427-3f99f9992bc2",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0126.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/38bb9fa6-ecb7-4ae3-8427-3f99f9992bc2/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0126.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/38bb9fa6-ecb7-4ae3-8427-3f99f9992bc2",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0126.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -9173,11 +9173,11 @@
           "@type": "sc:Canvas",
           "label": "125",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/9b3a78f9-676d-42b9-ae44-acdafffa5f7d/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0127.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/9b3a78f9-676d-42b9-ae44-acdafffa5f7d",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0127.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -9214,18 +9214,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/9b3a78f9-676d-42b9-ae44-acdafffa5f7d",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0127.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/9b3a78f9-676d-42b9-ae44-acdafffa5f7d/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0127.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9b3a78f9-676d-42b9-ae44-acdafffa5f7d",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0127.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -9245,11 +9245,11 @@
           "@type": "sc:Canvas",
           "label": "126",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/8c1bc45e-8350-4ba3-90f3-cb35e6962253/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0128.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/8c1bc45e-8350-4ba3-90f3-cb35e6962253",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0128.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -9286,18 +9286,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/8c1bc45e-8350-4ba3-90f3-cb35e6962253",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0128.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/8c1bc45e-8350-4ba3-90f3-cb35e6962253/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0128.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/8c1bc45e-8350-4ba3-90f3-cb35e6962253",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0128.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -9317,11 +9317,11 @@
           "@type": "sc:Canvas",
           "label": "127",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/fd0c8180-ede5-4dec-a5c6-e3ddc413a8b4/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0129.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/fd0c8180-ede5-4dec-a5c6-e3ddc413a8b4",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0129.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -9358,18 +9358,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/fd0c8180-ede5-4dec-a5c6-e3ddc413a8b4",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0129.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/fd0c8180-ede5-4dec-a5c6-e3ddc413a8b4/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0129.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/fd0c8180-ede5-4dec-a5c6-e3ddc413a8b4",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0129.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -9389,11 +9389,11 @@
           "@type": "sc:Canvas",
           "label": "128",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/0bb5e499-bccb-452a-9853-e28be6be5485/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0130.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/0bb5e499-bccb-452a-9853-e28be6be5485",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0130.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -9430,18 +9430,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/0bb5e499-bccb-452a-9853-e28be6be5485",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0130.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/0bb5e499-bccb-452a-9853-e28be6be5485/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0130.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0bb5e499-bccb-452a-9853-e28be6be5485",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0130.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -9461,11 +9461,11 @@
           "@type": "sc:Canvas",
           "label": "129",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/14c2de77-e455-4943-984f-483016a0a0e4/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0131.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/14c2de77-e455-4943-984f-483016a0a0e4",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0131.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -9502,18 +9502,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/14c2de77-e455-4943-984f-483016a0a0e4",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0131.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/14c2de77-e455-4943-984f-483016a0a0e4/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0131.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/14c2de77-e455-4943-984f-483016a0a0e4",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0131.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -9533,11 +9533,11 @@
           "@type": "sc:Canvas",
           "label": "130",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/e2052ca1-9013-465f-ac77-163af8abe45d/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0132.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/e2052ca1-9013-465f-ac77-163af8abe45d",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0132.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -9574,18 +9574,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/e2052ca1-9013-465f-ac77-163af8abe45d",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0132.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/e2052ca1-9013-465f-ac77-163af8abe45d/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0132.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/e2052ca1-9013-465f-ac77-163af8abe45d",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0132.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -9605,11 +9605,11 @@
           "@type": "sc:Canvas",
           "label": "131",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/a43735bf-37f7-4de4-ba83-d56f562554dd/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0133.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/a43735bf-37f7-4de4-ba83-d56f562554dd",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0133.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -9646,18 +9646,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/a43735bf-37f7-4de4-ba83-d56f562554dd",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0133.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/a43735bf-37f7-4de4-ba83-d56f562554dd/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0133.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a43735bf-37f7-4de4-ba83-d56f562554dd",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0133.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -9677,11 +9677,11 @@
           "@type": "sc:Canvas",
           "label": "132",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/46b063b1-cee6-4a20-874d-232fd4848baa/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0134.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/46b063b1-cee6-4a20-874d-232fd4848baa",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0134.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -9718,18 +9718,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/46b063b1-cee6-4a20-874d-232fd4848baa",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0134.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/46b063b1-cee6-4a20-874d-232fd4848baa/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0134.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/46b063b1-cee6-4a20-874d-232fd4848baa",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0134.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -9749,11 +9749,11 @@
           "@type": "sc:Canvas",
           "label": "133",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/a8ca5381-3cdc-4e43-8fd8-e38fee1ab8c7/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0135.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/a8ca5381-3cdc-4e43-8fd8-e38fee1ab8c7",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0135.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -9790,18 +9790,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/a8ca5381-3cdc-4e43-8fd8-e38fee1ab8c7",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0135.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/a8ca5381-3cdc-4e43-8fd8-e38fee1ab8c7/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0135.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a8ca5381-3cdc-4e43-8fd8-e38fee1ab8c7",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0135.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -9821,11 +9821,11 @@
           "@type": "sc:Canvas",
           "label": "134",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/82590f0a-94dc-4d91-b714-ad09311078e0/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0136.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/82590f0a-94dc-4d91-b714-ad09311078e0",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0136.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -9862,18 +9862,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/82590f0a-94dc-4d91-b714-ad09311078e0",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0136.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/82590f0a-94dc-4d91-b714-ad09311078e0/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0136.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/82590f0a-94dc-4d91-b714-ad09311078e0",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0136.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -9893,11 +9893,11 @@
           "@type": "sc:Canvas",
           "label": "135",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/469b4204-d0d6-4dd2-967f-81432004abd3/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0137.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/469b4204-d0d6-4dd2-967f-81432004abd3",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0137.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -9934,18 +9934,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/469b4204-d0d6-4dd2-967f-81432004abd3",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0137.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/469b4204-d0d6-4dd2-967f-81432004abd3/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0137.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/469b4204-d0d6-4dd2-967f-81432004abd3",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0137.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -9965,11 +9965,11 @@
           "@type": "sc:Canvas",
           "label": "136",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/9c63c1bf-ba12-4f9a-81bf-668fd7d799d9/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0138.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/9c63c1bf-ba12-4f9a-81bf-668fd7d799d9",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0138.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -10006,18 +10006,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/9c63c1bf-ba12-4f9a-81bf-668fd7d799d9",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0138.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/9c63c1bf-ba12-4f9a-81bf-668fd7d799d9/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0138.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9c63c1bf-ba12-4f9a-81bf-668fd7d799d9",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0138.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -10037,11 +10037,11 @@
           "@type": "sc:Canvas",
           "label": "137",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/818a6ccb-cfc1-4118-8431-89621dea4554/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0139.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/818a6ccb-cfc1-4118-8431-89621dea4554",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0139.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -10078,18 +10078,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/818a6ccb-cfc1-4118-8431-89621dea4554",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0139.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/818a6ccb-cfc1-4118-8431-89621dea4554/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0139.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/818a6ccb-cfc1-4118-8431-89621dea4554",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0139.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -10109,11 +10109,11 @@
           "@type": "sc:Canvas",
           "label": "138",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/803a8443-7dc4-45b4-ad03-5c53ecb727a4/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0140.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/803a8443-7dc4-45b4-ad03-5c53ecb727a4",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0140.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -10150,18 +10150,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/803a8443-7dc4-45b4-ad03-5c53ecb727a4",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0140.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/803a8443-7dc4-45b4-ad03-5c53ecb727a4/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0140.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/803a8443-7dc4-45b4-ad03-5c53ecb727a4",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0140.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -10181,11 +10181,11 @@
           "@type": "sc:Canvas",
           "label": "139",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/d496b718-dd2a-4917-b2b9-be981782a242/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0141.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/d496b718-dd2a-4917-b2b9-be981782a242",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0141.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -10222,18 +10222,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/d496b718-dd2a-4917-b2b9-be981782a242",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0141.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/d496b718-dd2a-4917-b2b9-be981782a242/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0141.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/d496b718-dd2a-4917-b2b9-be981782a242",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0141.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -10253,11 +10253,11 @@
           "@type": "sc:Canvas",
           "label": "140",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/a9cf57e0-51ff-4568-8e73-74dce92fca66/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0142.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/a9cf57e0-51ff-4568-8e73-74dce92fca66",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0142.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -10294,18 +10294,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/a9cf57e0-51ff-4568-8e73-74dce92fca66",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0142.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/a9cf57e0-51ff-4568-8e73-74dce92fca66/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0142.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a9cf57e0-51ff-4568-8e73-74dce92fca66",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0142.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -10325,11 +10325,11 @@
           "@type": "sc:Canvas",
           "label": "141",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/c8d4d340-5203-4ced-ab2a-7e03723ffd4f/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0143.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/c8d4d340-5203-4ced-ab2a-7e03723ffd4f",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0143.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -10366,18 +10366,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/c8d4d340-5203-4ced-ab2a-7e03723ffd4f",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0143.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/c8d4d340-5203-4ced-ab2a-7e03723ffd4f/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0143.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c8d4d340-5203-4ced-ab2a-7e03723ffd4f",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0143.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -10397,11 +10397,11 @@
           "@type": "sc:Canvas",
           "label": "142",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/abff6eb7-176b-476e-bbea-f67737beba58/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0144.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/abff6eb7-176b-476e-bbea-f67737beba58",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0144.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -10438,18 +10438,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/abff6eb7-176b-476e-bbea-f67737beba58",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0144.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/abff6eb7-176b-476e-bbea-f67737beba58/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0144.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/abff6eb7-176b-476e-bbea-f67737beba58",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0144.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -10469,11 +10469,11 @@
           "@type": "sc:Canvas",
           "label": "143",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/4453d0b8-3dd1-4c59-b66f-3130881b691b/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0145.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/4453d0b8-3dd1-4c59-b66f-3130881b691b",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0145.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -10510,18 +10510,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/4453d0b8-3dd1-4c59-b66f-3130881b691b",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0145.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/4453d0b8-3dd1-4c59-b66f-3130881b691b/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0145.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4453d0b8-3dd1-4c59-b66f-3130881b691b",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0145.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -10541,11 +10541,11 @@
           "@type": "sc:Canvas",
           "label": "144",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/aebf84fb-308a-4211-bc5d-6112cb31d086/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0146.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/aebf84fb-308a-4211-bc5d-6112cb31d086",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0146.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -10582,18 +10582,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/aebf84fb-308a-4211-bc5d-6112cb31d086",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0146.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/aebf84fb-308a-4211-bc5d-6112cb31d086/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0146.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/aebf84fb-308a-4211-bc5d-6112cb31d086",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0146.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -10613,11 +10613,11 @@
           "@type": "sc:Canvas",
           "label": "145",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/64fa790f-85b2-4c40-92a1-a4013942d2b7/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0147.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/64fa790f-85b2-4c40-92a1-a4013942d2b7",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0147.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -10654,18 +10654,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/64fa790f-85b2-4c40-92a1-a4013942d2b7",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0147.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/64fa790f-85b2-4c40-92a1-a4013942d2b7/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0147.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/64fa790f-85b2-4c40-92a1-a4013942d2b7",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0147.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -10685,11 +10685,11 @@
           "@type": "sc:Canvas",
           "label": "146",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/b8296b22-682a-4acf-93e9-71b8fd5904fd/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0148.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/b8296b22-682a-4acf-93e9-71b8fd5904fd",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0148.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -10726,18 +10726,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b8296b22-682a-4acf-93e9-71b8fd5904fd",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0148.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/b8296b22-682a-4acf-93e9-71b8fd5904fd/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0148.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/b8296b22-682a-4acf-93e9-71b8fd5904fd",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0148.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -10757,11 +10757,11 @@
           "@type": "sc:Canvas",
           "label": "147",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/11b3f3f0-c587-4f8d-9643-514e6e885421/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0149.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/11b3f3f0-c587-4f8d-9643-514e6e885421",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0149.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -10798,18 +10798,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/11b3f3f0-c587-4f8d-9643-514e6e885421",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0149.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/11b3f3f0-c587-4f8d-9643-514e6e885421/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0149.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/11b3f3f0-c587-4f8d-9643-514e6e885421",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0149.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -10829,11 +10829,11 @@
           "@type": "sc:Canvas",
           "label": "148",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/3e844895-dd93-4519-afbd-188dda801a19/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0150.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/3e844895-dd93-4519-afbd-188dda801a19",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0150.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -10870,18 +10870,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/3e844895-dd93-4519-afbd-188dda801a19",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0150.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/3e844895-dd93-4519-afbd-188dda801a19/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0150.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/3e844895-dd93-4519-afbd-188dda801a19",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0150.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -10901,11 +10901,11 @@
           "@type": "sc:Canvas",
           "label": "149",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/4f22b884-7db2-4a74-9578-88be9f730ecc/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0151.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/4f22b884-7db2-4a74-9578-88be9f730ecc",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0151.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -10942,18 +10942,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/4f22b884-7db2-4a74-9578-88be9f730ecc",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0151.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/4f22b884-7db2-4a74-9578-88be9f730ecc/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0151.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4f22b884-7db2-4a74-9578-88be9f730ecc",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0151.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -10973,11 +10973,11 @@
           "@type": "sc:Canvas",
           "label": "150",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/87099d91-8fa4-4e3c-af59-c8901cf00239/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0152.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/87099d91-8fa4-4e3c-af59-c8901cf00239",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0152.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -11014,18 +11014,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/87099d91-8fa4-4e3c-af59-c8901cf00239",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0152.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/87099d91-8fa4-4e3c-af59-c8901cf00239/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0152.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/87099d91-8fa4-4e3c-af59-c8901cf00239",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0152.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -11045,11 +11045,11 @@
           "@type": "sc:Canvas",
           "label": "151",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/631e2428-75b4-4ae9-bb0e-41cb2468ef96/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0153.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/631e2428-75b4-4ae9-bb0e-41cb2468ef96",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0153.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -11086,18 +11086,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/631e2428-75b4-4ae9-bb0e-41cb2468ef96",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0153.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/631e2428-75b4-4ae9-bb0e-41cb2468ef96/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0153.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/631e2428-75b4-4ae9-bb0e-41cb2468ef96",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0153.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -11117,11 +11117,11 @@
           "@type": "sc:Canvas",
           "label": "152",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/1088afac-82ed-4851-be3d-6c8541a18132/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0154.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/1088afac-82ed-4851-be3d-6c8541a18132",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0154.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -11158,18 +11158,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/1088afac-82ed-4851-be3d-6c8541a18132",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0154.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/1088afac-82ed-4851-be3d-6c8541a18132/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0154.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/1088afac-82ed-4851-be3d-6c8541a18132",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0154.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -11189,11 +11189,11 @@
           "@type": "sc:Canvas",
           "label": "153",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/1f585469-375b-42d0-bb8e-4b6d9e781f23/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0155.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/1f585469-375b-42d0-bb8e-4b6d9e781f23",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0155.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -11230,18 +11230,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/1f585469-375b-42d0-bb8e-4b6d9e781f23",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0155.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/1f585469-375b-42d0-bb8e-4b6d9e781f23/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0155.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/1f585469-375b-42d0-bb8e-4b6d9e781f23",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0155.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -11261,11 +11261,11 @@
           "@type": "sc:Canvas",
           "label": "154",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/9faa7db6-866b-4730-8253-cc020fd45225/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0156.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/9faa7db6-866b-4730-8253-cc020fd45225",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0156.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -11302,18 +11302,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/9faa7db6-866b-4730-8253-cc020fd45225",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0156.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/9faa7db6-866b-4730-8253-cc020fd45225/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0156.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9faa7db6-866b-4730-8253-cc020fd45225",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0156.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -11333,11 +11333,11 @@
           "@type": "sc:Canvas",
           "label": "155",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/28168c88-41b3-4bed-90cc-af3c8bf25f53/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0157.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/28168c88-41b3-4bed-90cc-af3c8bf25f53",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0157.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -11374,18 +11374,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/28168c88-41b3-4bed-90cc-af3c8bf25f53",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0157.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/28168c88-41b3-4bed-90cc-af3c8bf25f53/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0157.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/28168c88-41b3-4bed-90cc-af3c8bf25f53",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0157.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -11405,11 +11405,11 @@
           "@type": "sc:Canvas",
           "label": "156",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/bc9ff051-2200-4c1d-810a-9c11d57b87b3/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0158.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/bc9ff051-2200-4c1d-810a-9c11d57b87b3",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0158.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -11446,18 +11446,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/bc9ff051-2200-4c1d-810a-9c11d57b87b3",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0158.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/bc9ff051-2200-4c1d-810a-9c11d57b87b3/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0158.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/bc9ff051-2200-4c1d-810a-9c11d57b87b3",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0158.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -11477,11 +11477,11 @@
           "@type": "sc:Canvas",
           "label": "157",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/5017c3eb-4b07-4664-b947-299fa0def77a/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0159.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/5017c3eb-4b07-4664-b947-299fa0def77a",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0159.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -11518,18 +11518,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/5017c3eb-4b07-4664-b947-299fa0def77a",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0159.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/5017c3eb-4b07-4664-b947-299fa0def77a/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0159.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5017c3eb-4b07-4664-b947-299fa0def77a",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0159.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -11549,11 +11549,11 @@
           "@type": "sc:Canvas",
           "label": "158",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/9a5e71c4-9152-459d-a37d-8bc0acf6895c/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0160.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/9a5e71c4-9152-459d-a37d-8bc0acf6895c",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0160.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -11590,18 +11590,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/9a5e71c4-9152-459d-a37d-8bc0acf6895c",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0160.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/9a5e71c4-9152-459d-a37d-8bc0acf6895c/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0160.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9a5e71c4-9152-459d-a37d-8bc0acf6895c",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0160.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -11621,11 +11621,11 @@
           "@type": "sc:Canvas",
           "label": "159",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/9c8a8d8a-a5e7-4edd-b074-908263610154/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0161.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/9c8a8d8a-a5e7-4edd-b074-908263610154",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0161.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -11662,18 +11662,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/9c8a8d8a-a5e7-4edd-b074-908263610154",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0161.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/9c8a8d8a-a5e7-4edd-b074-908263610154/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0161.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9c8a8d8a-a5e7-4edd-b074-908263610154",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0161.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -11693,11 +11693,11 @@
           "@type": "sc:Canvas",
           "label": "160",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/f2507d05-e603-460d-982f-9dc47852c3b1/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0162.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/f2507d05-e603-460d-982f-9dc47852c3b1",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0162.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -11734,18 +11734,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/f2507d05-e603-460d-982f-9dc47852c3b1",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0162.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/f2507d05-e603-460d-982f-9dc47852c3b1/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0162.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f2507d05-e603-460d-982f-9dc47852c3b1",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0162.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -11765,11 +11765,11 @@
           "@type": "sc:Canvas",
           "label": "161",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/f9b4f22b-2b8b-42d7-9ec9-1a47c3cedaf1/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0163.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/f9b4f22b-2b8b-42d7-9ec9-1a47c3cedaf1",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0163.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -11806,18 +11806,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/f9b4f22b-2b8b-42d7-9ec9-1a47c3cedaf1",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0163.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/f9b4f22b-2b8b-42d7-9ec9-1a47c3cedaf1/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0163.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f9b4f22b-2b8b-42d7-9ec9-1a47c3cedaf1",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0163.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -11837,11 +11837,11 @@
           "@type": "sc:Canvas",
           "label": "162",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/2646c0ef-8728-4b5a-97f9-a8ea4c98c1e0/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0164.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/2646c0ef-8728-4b5a-97f9-a8ea4c98c1e0",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0164.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -11878,18 +11878,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/2646c0ef-8728-4b5a-97f9-a8ea4c98c1e0",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0164.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/2646c0ef-8728-4b5a-97f9-a8ea4c98c1e0/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0164.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/2646c0ef-8728-4b5a-97f9-a8ea4c98c1e0",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0164.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -11909,11 +11909,11 @@
           "@type": "sc:Canvas",
           "label": "163",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/39b11207-988c-4c7e-802b-3728dd219d4e/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0165.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/39b11207-988c-4c7e-802b-3728dd219d4e",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0165.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -11950,18 +11950,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/39b11207-988c-4c7e-802b-3728dd219d4e",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0165.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/39b11207-988c-4c7e-802b-3728dd219d4e/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0165.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/39b11207-988c-4c7e-802b-3728dd219d4e",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0165.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -11981,11 +11981,11 @@
           "@type": "sc:Canvas",
           "label": "164",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/efa28efa-f277-4905-b858-68ba57405bc7/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0166.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/efa28efa-f277-4905-b858-68ba57405bc7",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0166.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -12022,18 +12022,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/efa28efa-f277-4905-b858-68ba57405bc7",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0166.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/efa28efa-f277-4905-b858-68ba57405bc7/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0166.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/efa28efa-f277-4905-b858-68ba57405bc7",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0166.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -12053,11 +12053,11 @@
           "@type": "sc:Canvas",
           "label": "165",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/46e44e39-2818-4974-8d67-24107c2bc7eb/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0167.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/46e44e39-2818-4974-8d67-24107c2bc7eb",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0167.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -12094,18 +12094,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/46e44e39-2818-4974-8d67-24107c2bc7eb",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0167.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/46e44e39-2818-4974-8d67-24107c2bc7eb/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0167.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/46e44e39-2818-4974-8d67-24107c2bc7eb",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0167.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -12125,11 +12125,11 @@
           "@type": "sc:Canvas",
           "label": "166",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/46d21e00-d6ad-451f-aae1-2ccf0f43d83d/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0168.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/46d21e00-d6ad-451f-aae1-2ccf0f43d83d",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0168.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -12166,18 +12166,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/46d21e00-d6ad-451f-aae1-2ccf0f43d83d",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0168.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/46d21e00-d6ad-451f-aae1-2ccf0f43d83d/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0168.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/46d21e00-d6ad-451f-aae1-2ccf0f43d83d",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0168.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -12197,11 +12197,11 @@
           "@type": "sc:Canvas",
           "label": "167",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/779a6ec3-8fad-4a26-b1fc-9510340c2841/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0169.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/779a6ec3-8fad-4a26-b1fc-9510340c2841",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0169.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -12238,18 +12238,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/779a6ec3-8fad-4a26-b1fc-9510340c2841",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0169.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/779a6ec3-8fad-4a26-b1fc-9510340c2841/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0169.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/779a6ec3-8fad-4a26-b1fc-9510340c2841",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0169.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -12269,11 +12269,11 @@
           "@type": "sc:Canvas",
           "label": "168",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/5acd56f5-5a88-4642-9941-2b8650b7f906/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0170.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/5acd56f5-5a88-4642-9941-2b8650b7f906",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0170.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -12310,18 +12310,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/5acd56f5-5a88-4642-9941-2b8650b7f906",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0170.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/5acd56f5-5a88-4642-9941-2b8650b7f906/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0170.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/5acd56f5-5a88-4642-9941-2b8650b7f906",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0170.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -12341,11 +12341,11 @@
           "@type": "sc:Canvas",
           "label": "169",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/b3b62dd2-e383-47c0-b302-a5946cbedb69/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0171.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/b3b62dd2-e383-47c0-b302-a5946cbedb69",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0171.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -12382,18 +12382,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b3b62dd2-e383-47c0-b302-a5946cbedb69",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0171.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/b3b62dd2-e383-47c0-b302-a5946cbedb69/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0171.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/b3b62dd2-e383-47c0-b302-a5946cbedb69",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0171.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -12413,11 +12413,11 @@
           "@type": "sc:Canvas",
           "label": "170",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/bf81ecd8-5df9-4ddf-bd7a-8c483f5b99fd/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0172.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/bf81ecd8-5df9-4ddf-bd7a-8c483f5b99fd",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0172.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -12454,18 +12454,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/bf81ecd8-5df9-4ddf-bd7a-8c483f5b99fd",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0172.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/bf81ecd8-5df9-4ddf-bd7a-8c483f5b99fd/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0172.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/bf81ecd8-5df9-4ddf-bd7a-8c483f5b99fd",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0172.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -12485,11 +12485,11 @@
           "@type": "sc:Canvas",
           "label": "171",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/39d758f4-96b6-4c74-a599-bdd7fa554fb8/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0173.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/39d758f4-96b6-4c74-a599-bdd7fa554fb8",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0173.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -12526,18 +12526,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/39d758f4-96b6-4c74-a599-bdd7fa554fb8",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0173.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/39d758f4-96b6-4c74-a599-bdd7fa554fb8/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0173.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/39d758f4-96b6-4c74-a599-bdd7fa554fb8",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0173.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -12557,11 +12557,11 @@
           "@type": "sc:Canvas",
           "label": "172",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/749a5fc1-9d13-418d-8945-aecfdbb695e9/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0174.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/749a5fc1-9d13-418d-8945-aecfdbb695e9",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0174.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -12598,18 +12598,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/749a5fc1-9d13-418d-8945-aecfdbb695e9",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0174.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/749a5fc1-9d13-418d-8945-aecfdbb695e9/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0174.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/749a5fc1-9d13-418d-8945-aecfdbb695e9",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0174.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -12629,11 +12629,11 @@
           "@type": "sc:Canvas",
           "label": "173",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/c6f84338-2032-4d88-843d-7261b748a93e/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0175.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/c6f84338-2032-4d88-843d-7261b748a93e",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0175.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -12670,18 +12670,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/c6f84338-2032-4d88-843d-7261b748a93e",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0175.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/c6f84338-2032-4d88-843d-7261b748a93e/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0175.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c6f84338-2032-4d88-843d-7261b748a93e",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0175.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -12701,11 +12701,11 @@
           "@type": "sc:Canvas",
           "label": "174",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/52800c26-4537-4b44-af10-af88c058b02e/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0176.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/52800c26-4537-4b44-af10-af88c058b02e",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0176.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -12742,18 +12742,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/52800c26-4537-4b44-af10-af88c058b02e",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0176.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/52800c26-4537-4b44-af10-af88c058b02e/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0176.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/52800c26-4537-4b44-af10-af88c058b02e",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0176.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -12773,11 +12773,11 @@
           "@type": "sc:Canvas",
           "label": "175",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/c0097124-0c11-4271-96f4-b3661d9d2261/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0177.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/c0097124-0c11-4271-96f4-b3661d9d2261",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0177.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -12814,18 +12814,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/c0097124-0c11-4271-96f4-b3661d9d2261",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0177.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/c0097124-0c11-4271-96f4-b3661d9d2261/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0177.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c0097124-0c11-4271-96f4-b3661d9d2261",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0177.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -12845,11 +12845,11 @@
           "@type": "sc:Canvas",
           "label": "176",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/9fd01b5a-0321-4eb7-bd2c-a5a8bffe778f/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0178.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/9fd01b5a-0321-4eb7-bd2c-a5a8bffe778f",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0178.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -12886,18 +12886,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/9fd01b5a-0321-4eb7-bd2c-a5a8bffe778f",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0178.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/9fd01b5a-0321-4eb7-bd2c-a5a8bffe778f/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0178.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9fd01b5a-0321-4eb7-bd2c-a5a8bffe778f",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0178.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -12917,11 +12917,11 @@
           "@type": "sc:Canvas",
           "label": "177",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/fc9caa90-86fb-452e-b57d-31b9c2686df6/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0179.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/fc9caa90-86fb-452e-b57d-31b9c2686df6",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0179.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -12958,18 +12958,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/fc9caa90-86fb-452e-b57d-31b9c2686df6",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0179.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/fc9caa90-86fb-452e-b57d-31b9c2686df6/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0179.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/fc9caa90-86fb-452e-b57d-31b9c2686df6",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0179.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -12989,11 +12989,11 @@
           "@type": "sc:Canvas",
           "label": "178",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/c4266147-7bd7-49e5-bdf6-8e585ef9e570/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0180.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/c4266147-7bd7-49e5-bdf6-8e585ef9e570",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0180.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -13030,18 +13030,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/c4266147-7bd7-49e5-bdf6-8e585ef9e570",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0180.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/c4266147-7bd7-49e5-bdf6-8e585ef9e570/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0180.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/c4266147-7bd7-49e5-bdf6-8e585ef9e570",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0180.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -13061,11 +13061,11 @@
           "@type": "sc:Canvas",
           "label": "179",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/9c6a2cd0-5172-4826-ac7b-6120898fce93/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0181.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/9c6a2cd0-5172-4826-ac7b-6120898fce93",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0181.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -13102,18 +13102,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/9c6a2cd0-5172-4826-ac7b-6120898fce93",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0181.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/9c6a2cd0-5172-4826-ac7b-6120898fce93/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0181.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/9c6a2cd0-5172-4826-ac7b-6120898fce93",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0181.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -13133,11 +13133,11 @@
           "@type": "sc:Canvas",
           "label": "180",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/76fa43cd-f9bd-436e-94a1-9c9e209b73fc/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0182.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/76fa43cd-f9bd-436e-94a1-9c9e209b73fc",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0182.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -13174,18 +13174,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/76fa43cd-f9bd-436e-94a1-9c9e209b73fc",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0182.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/76fa43cd-f9bd-436e-94a1-9c9e209b73fc/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0182.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/76fa43cd-f9bd-436e-94a1-9c9e209b73fc",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0182.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -13205,11 +13205,11 @@
           "@type": "sc:Canvas",
           "label": "181",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/2276b11d-6b03-4486-a511-bace06602bfa/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0183.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/2276b11d-6b03-4486-a511-bace06602bfa",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0183.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -13246,18 +13246,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/2276b11d-6b03-4486-a511-bace06602bfa",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0183.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/2276b11d-6b03-4486-a511-bace06602bfa/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0183.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/2276b11d-6b03-4486-a511-bace06602bfa",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0183.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -13277,11 +13277,11 @@
           "@type": "sc:Canvas",
           "label": "182",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/a27710c3-41a5-49bb-abd7-b388a9376ab4/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0184.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/a27710c3-41a5-49bb-abd7-b388a9376ab4",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0184.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -13318,18 +13318,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/a27710c3-41a5-49bb-abd7-b388a9376ab4",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0184.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/a27710c3-41a5-49bb-abd7-b388a9376ab4/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0184.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/a27710c3-41a5-49bb-abd7-b388a9376ab4",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0184.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -13349,11 +13349,11 @@
           "@type": "sc:Canvas",
           "label": "183",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/361545a4-56fe-498d-8bea-bf7e9be37718/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0185.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/361545a4-56fe-498d-8bea-bf7e9be37718",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0185.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -13390,18 +13390,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/361545a4-56fe-498d-8bea-bf7e9be37718",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0185.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/361545a4-56fe-498d-8bea-bf7e9be37718/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0185.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/361545a4-56fe-498d-8bea-bf7e9be37718",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0185.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -13421,11 +13421,11 @@
           "@type": "sc:Canvas",
           "label": " - ",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/4e511d74-24f2-4f79-b035-fbf6adfd2b74/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0186.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/4e511d74-24f2-4f79-b035-fbf6adfd2b74",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0186.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -13462,18 +13462,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/4e511d74-24f2-4f79-b035-fbf6adfd2b74",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0186.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/4e511d74-24f2-4f79-b035-fbf6adfd2b74/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0186.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/4e511d74-24f2-4f79-b035-fbf6adfd2b74",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0186.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -13493,11 +13493,11 @@
           "@type": "sc:Canvas",
           "label": " - ",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/0b6ff152-7d87-4dac-a4a4-3365684e2800/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0187.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/0b6ff152-7d87-4dac-a4a4-3365684e2800",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0187.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -13534,18 +13534,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/0b6ff152-7d87-4dac-a4a4-3365684e2800",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0187.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/0b6ff152-7d87-4dac-a4a4-3365684e2800/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0187.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/0b6ff152-7d87-4dac-a4a4-3365684e2800",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0187.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -13565,11 +13565,11 @@
           "@type": "sc:Canvas",
           "label": " - ",
           "thumbnail": {
-            "@id": "https://dlcs.io/thumbs/wellcome/1/f6b40b99-2e66-42bc-80b7-26683b4f49dc/full/58,100/0/default.jpg",
+            "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0188.jp2/full/58,100/0/default.jpg",
             "@type": "dctypes:Image",
             "service": {
               "@context": "http://iiif.io/api/image/2/context.json",
-              "@id": "https://dlcs.io/thumbs/wellcome/1/f6b40b99-2e66-42bc-80b7-26683b4f49dc",
+              "@id": "https://dlcs.io/thumbs/wellcome/5/b19792827_0188.jp2",
               "protocol": "http://iiif.io/api/image",
               "height": 1024,
               "width": 595,
@@ -13606,18 +13606,18 @@
           "width": 1476,
           "images": [
             {
-              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/f6b40b99-2e66-42bc-80b7-26683b4f49dc",
+              "@id": "https://wellcomelibrary.org/iiif/b19792827/imageanno/b19792827_0188.jp2",
               "@type": "oa:Annotation",
               "motivation": "sc:painting",
               "resource": {
-                "@id": "https://dlcs.io/iiif-img/wellcome/1/f6b40b99-2e66-42bc-80b7-26683b4f49dc/full/!1024,1024/0/default.jpg",
+                "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0188.jp2/full/!1024,1024/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
                 "height": 1024,
                 "width": 595,
                 "service": {
                   "@context": "http://iiif.io/api/image/2/context.json",
-                  "@id": "https://dlcs.io/iiif-img/wellcome/1/f6b40b99-2e66-42bc-80b7-26683b4f49dc",
+                  "@id": "https://dlcs.io/iiif-img/wellcome/5/b19792827_0188.jp2",
                   "profile": "http://iiif.io/api/image/2/level1.json"
                 }
               },
@@ -13662,6 +13662,18 @@
         "https://wellcomelibrary.org/iiif/b19792827/canvas/c183",
         "https://wellcomelibrary.org/iiif/b19792827/canvas/c184"
       ]
+    }
+  ],
+  "otherContent": [
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b19792827/images",
+      "@type": "sc:AnnotationList",
+      "label": "OCR-identified images and figures for b19792827"
+    },
+    {
+      "@id": "https://wellcomelibrary.org/iiif/b19792827/allcontent",
+      "@type": "sc:AnnotationList",
+      "label": "All OCR-derived annotations for b19792827"
     }
   ]
 }


### PR DESCRIPTION
This PR upgrades the dependencies `dc-commons-springboot` and `dc-commons-springmvc` to their latest version and fixes some failing unit tests. Additionally it changes the java version to 11.